### PR TITLE
Allow a has_many :wrap association to manage items for a new_entry

### DIFF
--- a/lib/active_ldap/association/has_many_wrap.rb
+++ b/lib/active_ldap/association/has_many_wrap.rb
@@ -64,7 +64,7 @@ module ActiveLdap
 
         flatten_deeper(entries).each do |entry|
           infect_connection(entry)
-          result &&= insert_entry(entry)
+          insert_entry(entry) or result = false
           @target << entry
         end
 

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -420,11 +420,11 @@ EOX
           assert_equal([], group.members.to_a)
           assert_equal([], group.member_uid(true))
 
-          group.members = [user1]
+          group.members = [user1, user2]
 
           assert group.new_entry?
-          assert_equal([user1.uid], group.members.map {|x| x.uid })
-          assert_equal(user1.uid, group.member_uid)
+          assert_equal([user1.uid, user2.uid].sort, group.members.map {|x| x.uid }.sort)
+          assert_equal([user1.uid, user2.uid].sort, group.member_uid(true).sort)
 
           group.members = [user2]
 


### PR DESCRIPTION
Currently it's not possible to manage items in a has_many :wrap association for a new_entry.  There is a conditional in Association::Collection#insert_entry that checks for @owner.new_entry? and does nothing if it is.  This makes it very difficult when dealing with groups using the groupOfNames objectClass and the like where the members attribute is mandatory.

I've overridden this method in the Association::HasManyWrap class, and taken the conditional out.  It's not as DRY as it could be, but I'm wary of refactoring too much without being more familiar with the codebase.
