### PR TITLE
ruby-ldap is a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ gem 'activemodel', '~> 3.1.0'
 gem 'locale'
 gem 'fast_gettext'
 gem 'gettext_i18n_rails'
+gem 'ruby-ldap'
 
 group :development, :test do
-  gem 'ruby-ldap'
   gem 'net-ldap'
   gem 'jeweler'
   gem 'test-unit'


### PR DESCRIPTION
This pull request fixes the dependency chain for using active_ldap with Bundler.  Without this line, attempts to invoke ActiveLdap result in the error:

```
Foos.find :all # => LoadError: no such file to load -- net/ldap
```
