### PR TITLE
Honoring attributes in .find() arguments

### DIFF
--- a/lib/active_ldap/operations.rb
+++ b/lib/active_ldap/operations.rb
@@ -65,13 +65,13 @@ module ActiveLdap
         values = []
         options[:connection].search(search_options) do |dn, attrs|
           attributes = {}
-	  normalized_attributes = {}
+	        normalized_attributes = {}
           attrs.each do |key, _value|
               if attributes_filter.include?(key) || attributes_filter.include?('*')
                    normalized_attribute, normalized_value = normalize_attribute_options(key, _value)
                    attributes[normalized_attribute] ||= []
-		   attributes[normalized_attribute].concat(normalized_value)
-	      else
+		              attributes[normalized_attribute].concat(normalized_value)
+	            else
                 next
               end
           end


### PR DESCRIPTION
Hi,

This is a minor patch which honors the attribute filtering when doing find operations. without it, you would always get back all the attributes defined for the object. If no attributes are defined in the find arguments list, the '*' is added. When find_every calls search, search will skip over any attributes not defined in the filter unless '*' is defined.

``` diff
--- lib/active_ldap/operations.rb   2012-06-03 07:32:35.250085042 +0200
+++ /usr/local/lib/ruby/gems/1.9.1/gems/activeldap-3.1.1/lib/active_ldap/operations.rb  2012-06-03 07:34:40.606934200 +0200
@@ -31,6 +31,7 @@
         filter = options[:filter]
         prefix = options[:prefix]
         classes = options[:classes]
+   attributes_filter = options[:attributes]

         value = value.first if value.is_a?(Array) and value.first.size == 1

@@ -60,16 +61,19 @@
           :sort_by => options[:sort_by] || sort_by,
           :order => options[:order] || order,
         }
-
         options[:connection] ||= connection
         values = []
         options[:connection].search(search_options) do |dn, attrs|
           attributes = {}
+     normalized_attributes = {}
Honoring attributes arguments when passed to find.
           attrs.each do |key, _value|
-            normalized_attr, normalized_value =
-              normalize_attribute_options(key, _value)
-            attributes[normalized_attr] ||= []
-            attributes[normalized_attr].concat(normalized_value)
+              if attributes_filter.include?(key) || attributes_filter.include?('*')
+                   normalized_attribute, normalized_value = normalize_attribute_options(key, _value)
+                   attributes[normalized_attribute] ||= []
+          attributes[normalized_attribute].concat(normalized_value)
+         else
+                next
+              end
           end
           values << [dn, attributes]
         end
@@ -281,8 +285,8 @@
         order = options.delete(:order) || self.order
         limit = options.delete(:limit) if sort_by or order
         offset = options.delete(:offset) || offset
-        options[:attributes] |= ["objectClass"] if options[:attributes]
-
+   options[:attributes] = options.delete(:attributes) || ['*']
+   options[:attributes] |= ['objectClass']
         results = search(options).collect do |dn, attrs|
           instantiate([dn, attrs, {:connection => options[:connection]}])
         end
```
