### PR TITLE
Implicit railtie load.

### DIFF
--- a/lib/active_ldap.rb
+++ b/lib/active_ldap.rb
@@ -84,3 +84,4 @@ ACTIVE_LDAP_CONNECTION_ADAPTERS.each do |adapter|
 end
 
 require "active_ldap/entry"
+require 'active_ldap/railtie' if defined?(Rails)


### PR DESCRIPTION
(On rails 3.2.12)
The railtie is not loaded and the initializers cannot do their work.
