### PR TITLE
BUG FIX: fixed hash type detection regexp

### DIFF
--- a/lib/active_ldap/user_password.rb
+++ b/lib/active_ldap/user_password.rb
@@ -7,7 +7,7 @@ module ActiveLdap
   module UserPassword
     module_function
     def valid?(password, hashed_password)
-      unless /^\{([A-Z][A-Z\d]+)\}/ =~ hashed_password
+      unless /^\{([A-Za-z][A-Za-z\d]+)\}/ =~ hashed_password
         # Plain text password
         return hashed_password == password
       end


### PR DESCRIPTION
UserPassword.valid? treats passwords with lower case hash type ({crypt}.....) as plaintext password. This pull request contains a fix for that.
