### PR TITLE
Fix: the reference to rails doc page is broken

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -45,7 +45,7 @@ h2. Notes
 
 h2. Rails
 
-See "Rails":file.rails.html page for Rails integration.
+See "Rails":doc/text/rails.textile page for Rails integration.
 
 h2. Licence
 


### PR DESCRIPTION
fix reference to rails documentation.
