### PR TITLE
Make it easy for bundler to require active_ldap.

### DIFF
--- a/lib/activeldap.rb
+++ b/lib/activeldap.rb
@@ -1,0 +1,1 @@
+require 'active_ldap'


### PR DESCRIPTION
In default, bundler attempt to require 'activeldap' but no such file in lib dir.
Added 'activeldap' to resolve it.

Thanks, 
