### PR TITLE
Fix handling of boolean attributes

### DIFF
--- a/lib/active_ldap/attributes.rb
+++ b/lib/active_ldap/attributes.rb
@@ -20,7 +20,7 @@ module ActiveLdap
         when nil
           true
         else
-          value.blank?
+          value.to_s.blank?
         end
       end
 

--- a/lib/active_ldap/schema.rb
+++ b/lib/active_ldap/schema.rb
@@ -552,7 +552,7 @@ module ActiveLdap
         when Hash
           normalize_hash_value(value, have_binary_mark)
         else
-          if value.blank?
+          if value.to_s.blank?
             value = []
           else
             value = send_to_syntax(value, :normalize_value, value)

--- a/lib/active_ldap/validations.rb
+++ b/lib/active_ldap/validations.rb
@@ -147,7 +147,7 @@ module ActiveLdap
           next if required_attribute.read_only?
           next if _validation_skip_attributes.include?(real_name)
 
-          value = @data[real_name] || []
+          value = @data.has_key?(real_name) ? @data[real_name] : []
           next unless self.class.blank_value?(value)
 
           _schema ||= schema


### PR DESCRIPTION
My schema has an object class with a required boolean value.

Now, when I pass the Ruby false (FalseClass) to the attribute of the ActiveLdap-object, then the new value is not transferred to the server and validation fails.

Here I have a patch that will solve the problem. The main-problem is, that `false.blank?` will evaulate to `true`. Thus `false` is handled like an empty string. IMHO this is wrong. What`s your opinion?

Please can you review the patch? Any comments?

Bye, Robin.
