### PR TITLE
Handling connection resets when contacting LDAP

### DIFF
--- a/lib/active_ldap/adapter/net_ldap.rb
+++ b/lib/active_ldap/adapter/net_ldap.rb
@@ -142,7 +142,7 @@ module ActiveLdap
         result = log(name, info) do
           begin
             @connection.send(method, *args, &block)
-          rescue Errno::EPIPE
+          rescue Errno::EPIPE, Errno::ECONNRESET
             raise ConnectionError, "#{$!.class}: #{$!.message}"
           end
         end


### PR DESCRIPTION
This is to enable re-connection when connection resets happen on the existing LDAP connection
