### PR TITLE
Re-encode string value to prevent encoding errors in ruby 1.9+ when validating

### DIFF
--- a/lib/active_ldap/validations.rb
+++ b/lib/active_ldap/validations.rb
@@ -174,6 +174,8 @@ module ActiveLdap
         # Is it really proper location for setting encoding?
         if attribute.binary? and value.respond_to?(:force_encoding)
           value.force_encoding("ASCII-8BIT")
+        elsif value.is_a?(String)
+          value.try(:encode!, value.encoding,  value.encoding, :invalid => :replace)
         end
         next if self.class.blank_value?(value)
         validate_ldap_value(attribute, name, value)


### PR DESCRIPTION
Just a quick and dirty fix to be able to save UTF-8 encoded values with special characters like `é` or `ô`.

When you used ActiveLDAP outside a Rails application, you need to set the default encoding, like this in Ruby 1.9.x:

``` ruby
Encoding.default_internal = "UTF-8"
```

Strack trace:

```
c:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/activeldap-4.0.0/lib/active_ldap/attributes.rb:19:in `===': invalid byte sequence in UTF-8 (ArgumentError)
from c:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/activeldap-4.0.0/lib/active_ldap/attributes.rb:19:in `blank_value?'
from c:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/activeldap-4.0.0/lib/active_ldap/validations.rb:180:in `block in validate_ldap_values'
from c:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/activeldap-4.0.0/lib/active_ldap/validations.rb:173:in `each'
from c:/RailsInstaller/Ruby1.9.3/lib/ruby/gems/1.9.1/gems/activeldap-4.0.0/lib/active_ldap/validations.rb:173:in `validate_ldap_values'
...
```
