### PR TITLE
Support for Ruby on Rails 4.1.0

### DIFF
--- a/activeldap.gemspec
+++ b/activeldap.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.licenses = ["Ruby's", "GPLv2 or later"]
 
-  spec.add_dependency("activemodel", ["~> 4.0.0"])
+  spec.add_dependency("activemodel", ["> 4.0.0"])
   spec.add_dependency("locale")
   spec.add_dependency("gettext")
   spec.add_dependency("gettext_i18n_rails")


### PR DESCRIPTION
ActiveModel has increased its version.
