### PR TITLE
Nil exception in remove_connection, payload[:info'] is nil

### DIFF
--- a/lib/active_ldap/log_subscriber.rb
+++ b/lib/active_ldap/log_subscriber.rb
@@ -24,7 +24,7 @@ module ActiveLdap
 
       payload = event.payload
       label = payload[:name]
-      label += ": FAILED" if payload[:info][:exception]
+      label += ": FAILED" if !payload[:info].nil? && payload[:info][:exception]
       name = 'LDAP: %s (%.1fms)' % [label, event.duration]
       info = payload[:info].inspect
 


### PR DESCRIPTION
You can reproduce the problem with this code:

```
login_class = Class.new(ActiveLdap::Base)
login_class.setup_connection(:bind_dn => "dn", :password_block => Proc.new { password }, :allow_anonymous => false, :base => "base")
user = login_class.find(:first, :filter => "(|(mail=#{mail})(mailAlternateAddress=#{mail}))")
login_class.remove_connection
```

This is the error trace

```
Could not log "log_info.active_ldap" event. NoMethodError: undefined method `[]' for nil:NilClass 
["/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/log_subscriber.rb:27:in `log_info'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/subscriber.rb:91:in `finish'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/log_subscriber.rb:83:in `finish'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/notifications/fanout.rb:96:in `finish'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/notifications/fanout.rb:40:in `block in finish'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/notifications/fanout.rb:40:in `each'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/notifications/fanout.rb:40:in `finish'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/notifications/instrumenter.rb:36:in `finish'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/notifications/instrumenter.rb:25:in `instrument'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/adapter/base.rb:663:in `log'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/adapter/ldap.rb:198:in `execute'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/adapter/ldap.rb:67:in `block in unbind'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/adapter/base.rb:93:in `unbind'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/adapter/ldap.rb:66:in `unbind'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/adapter/base.rb:50:in `disconnect!'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activeldap-4.0.3/lib/active_ldap/connection.rb:140:in `remove_connection'",
 "(irb):10:in `irb_binding'", "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/workspace.rb:86:in `eval'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/workspace.rb:86:in `evaluate'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/context.rb:380:in `evaluate'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:492:in `block (2 levels) in eval_input'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:624:in `signal_status'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:489:in `block in eval_input'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/ruby-lex.rb:247:in `block (2 levels) in each_top_level_statement'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/ruby-lex.rb:233:in `loop'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/ruby-lex.rb:233:in `block in each_top_level_statement'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/ruby-lex.rb:232:in `catch'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/ruby-lex.rb:232:in `each_top_level_statement'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:488:in `eval_input'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:397:in `block in start'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:396:in `catch'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb.rb:396:in `start'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/console.rb:90:in `start'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/console.rb:9:in `start'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:69:in `console'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:40:in `run_command!'",
 "/home/fmbiete/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands.rb:17:in `<top (required)>'",
 "script/rails:6:in `require'", "script/rails:6:in `<main>'"]
```
