### PR TITLE
Remove include Enumerable from ActiveLdap::Base

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -656,8 +656,6 @@ module ActiveLdap
     self.recommended_classes = []
     self.excluded_classes = []
 
-    include Enumerable
-
     ### All instance methods, etc
 
     # new


### PR DESCRIPTION
Since e7f6ab87dccd427d24f7430c826fca15734533ad there has been no `#each` method to power Enumerable and so it's now a redundant include.

This surfaces as a problem when using `ActiveLdap::Base` subclasses in the RSpec 3 [`match_array` or `contains_exactly`](https://www.relishapp.com/rspec/rspec-expectations/v/3-1/docs/built-in-matchers/contain-exactly-matcher) matchers as they try to map over the value if it is `Enumerable` (see: [Line 142 of `with_matchers_cloned`](https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/matchers/composable.rb#L117-149)).  `ActiveLdap::Base` instances claim they are `Enumerable`, but have no `.each` method to power the `map` call.

Best option is just to remove it.
