### PR TITLE
Correct rails generate group documentation

### DIFF
--- a/doc/text/rails.textile
+++ b/doc/text/rails.textile
@@ -96,7 +96,7 @@ end
 You can also generate a Group model by the following command:
 
 <pre class="command">
-% script/rails generate model Group --classes PosixGroup
+% script/rails generate active_ldap:model Group --classes PosixGroup
 </pre>
 
 app/model/group.rb:


### PR DESCRIPTION
If you generate model Group rather than active_ldap:model Group you don't get
the correct app/model/group.rb created
