### PR TITLE
Fix extract_salt_for_crypt when encryption methods other than MD5 are used

### DIFF
--- a/lib/active_ldap/user_password.rb
+++ b/lib/active_ldap/user_password.rb
@@ -37,8 +37,8 @@ module ActiveLdap
     end
 
     def extract_salt_for_crypt(crypted_password)
-      if /^\$1\$/ =~ crypted_password
-        $MATCH + $POSTMATCH[0, 8].sub(/\$.*/, '') + "$"
+      if /^\$(1|5|6|2a)\$([a-zA-Z0-9.\/]{,16}\$)?/ =~ crypted_password
+        $MATCH
       else
         crypted_password[0, 2]
       end

--- a/test/test_user_password.rb
+++ b/test/test_user_password.rb
@@ -39,10 +39,13 @@ class TestUserPassword < Test::Unit::TestCase
   def test_extract_salt_for_crypt
     assert_extract_salt(:crypt, "AB", "ABCDE")
     assert_extract_salt(:crypt, "$1", "$1")
-    assert_extract_salt(:crypt, "$1$$", "$1$")
+    assert_extract_salt(:crypt, "$1$", "$1$")
     assert_extract_salt(:crypt, "$1$$", "$1$$")
     assert_extract_salt(:crypt, "$1$abcdefgh$", "$1$abcdefgh$")
-    assert_extract_salt(:crypt, "$1$abcdefgh$", "$1$abcdefghi$")
+    assert_extract_salt(:crypt, "$1$abcdefgh$", "$1$abcdefgh$")
+    assert_extract_salt(:crypt, "$5$abcdefgh$", "$5$abcdefgh$")
+    assert_extract_salt(:crypt, "$6$abcdefgh$", "$6$abcdefgh$")
+    assert_extract_salt(:crypt, "$2a$abcdefgh$", "$2a$abcdefgh$")
   end
 
   def test_md5


### PR DESCRIPTION
- Change the regex match so that it matches specific detail mentioned in the
  crypt(3) man page
  
  The crypt(3) man page suggests that:
    If salt is a character string starting with the characters
  "$id$" followed by a string terminated by "$":
    $id$salt$encrypted
  then instead of using the DES machine, id identifies the
  encryption method used and this then determines how the rest
  of the password string is interpreted.  The following values
  of id are supported:
  
  ID  | Method
  ─────────────────────────────────────────────────────────
  1   | MD5
  2a  | Blowfish (not in mainline glibc; added in some
      | Linux distributions)
  5   | SHA-256 (since glibc 2.7)
  6   | SHA-512 (since glibc 2.7)
  
  The characters in "salt" and "encrypted" are drawn from the
  set [a-zA-Z0-9./].
  
  MD5 worked with the original code, but none of the other mechanisms had the
  full salt returned
- The part of the regex that matches the salt is up to 16 characters, again
  as mentioned in the crypt(3) man page:
  
  The crypt(3) man page suggests that:
     "salt" stands for the up to 16 characters following "$id$" in
     the salt.  The encrypted part of the password string is the
     actual computed password.
- Updated the test for a salt simply containing $1$
  I believe the original test that this extracted salt should be $1$$ is
  incorrect and was only that way due to how the original code worked
- Added some extra tests to ensure that the new encryption methods return
  the extracted salt expected.
