### PR TITLE
Fix ruby 2.1 and 2.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - ruby-head
 #  - rbx
 #  - jruby
+sudo: true
 env:
   - JRUBY_OPTS="-Xcext.enabled=true"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - ruby-head
 #  - rbx
 #  - jruby
 sudo: true

--- a/lib/active_ldap/ldif.rb
+++ b/lib/active_ldap/ldif.rb
@@ -138,9 +138,11 @@ module ActiveLdap
       end
 
       def read_external_file
-        uri_string = @scanner.scan(URI::ABS_URI).chomp
-        raise uri_is_missing if uri_string.nil?
+        uri_string = @scanner.scan(URI::ABS_URI)
+        raise uri_is_missing_or_invalid if uri_string.nil?
+        uri_string.chomp!
         uri = nil
+
         begin
           uri = URI.parse(uri_string)
         rescue URI::Error
@@ -439,6 +441,10 @@ module ActiveLdap
 
       def invalid_uri(uri_string, message)
         invalid_ldif(_("URI is invalid: %s: %s") % [uri_string, message])
+      end
+
+      def uri_is_missing_or_invalid
+        invalid_ldif(_("URI is missing or invalid"))
       end
 
       def modify_spec_separator_is_missing

--- a/lib/active_ldap/ldif.rb
+++ b/lib/active_ldap/ldif.rb
@@ -138,7 +138,7 @@ module ActiveLdap
       end
 
       def read_external_file
-        uri_string = @scanner.scan(URI::ABS_URI)
+        uri_string = @scanner.scan(URI::ABS_URI).chomp
         raise uri_is_missing if uri_string.nil?
         uri = nil
         begin

--- a/test/test_ldif.rb
+++ b/test/test_ldif.rb
@@ -1247,6 +1247,27 @@ uid: hjensen
 EOL
   end
 
+  def test_record_with_external_file_reference_is_invalid
+    ldif_source = <<-EOL
+version: 1
+dn: cn=Horatio Jensen, ou=Product Testing, dc=airius, dc=com
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+cn: Horatio Jensen
+sn: Jensen
+uid: hjensen
+jpegphoto:< INVALID_URI
+EOL
+
+    ldif_source_with_error_mark = <<-EOL
+jpegphoto:< |@|INVALID_URI
+EOL
+
+    assert_invalid_ldif("URI is missing or invalid",
+                        ldif_source, 9, 13, ldif_source_with_error_mark)
+  end
+
   def test_records_with_option_attributes
     ldif_source = <<-EOL
 version: 1


### PR DESCRIPTION
URI::ABS_URI regexp has changed and does not work with ruby 2.1 and 2.2 the same way like before. This patch fix this.

I've also fixed run on travis. Since new docker based infrastructure they don't offer sudo ability. It can be enabled by "sudo: true" in config, but this uses old travis infrastructure. So in future this should be changed.