### PR TITLE
Support escaped spaces in DN

### DIFF
--- a/lib/active_ldap/distinguished_name.rb
+++ b/lib/active_ldap/distinguished_name.rb
@@ -62,7 +62,7 @@ module ActiveLdap
 
       HEX_PAIR = "(?:[\\da-fA-F]{2})"
       STRING_CHARS_RE = /[^,=\+<>\#;\\\"]*/ #
-      PAIR_RE = /\\([,=\+<>\#;]|\\|\"|(#{HEX_PAIR}))/ #
+      PAIR_RE = /\\([,=\+<>\#;]|\\|\"|\ |(#{HEX_PAIR}))/ #
       HEX_STRING_RE = /\#(#{HEX_PAIR}+)/ #
       def scan_attribute_value(scanner)
         if scanner.scan(HEX_STRING_RE)

--- a/test/test_dn.rb
+++ b/test/test_dn.rb
@@ -72,6 +72,13 @@ class TestDN < Test::Unit::TestCase
               "dc = \" l o c a l \" , dc = \"+n,\\\"e\\\";t\"")
   end
 
+  def test_parse_dn_with_spaces_in_attribute_value
+    assert_dn([["o", "xxx "], ["dc", "local"]], "o=xxx\\ ,dc=local")
+    assert_dn([["o", " xxx"], ["dc", "local"]], "o=\\ xxx,dc=local")
+    assert_dn([["o", "xxx yyy"], ["dc", "local"]], "o=xxx\\ yyy,dc=local")
+    assert_dn([["o", " xxx "], ["dc", "local"]], "o=\\ xxx\\ ,dc=local")
+  end
+
   def test_parse_dn_in_rfc2253
     assert_dn([
                {"cn" => "Steve Kille"},


### PR DESCRIPTION
DN could include spaces escaped by `\` in each of components, for example `o=xxx\ ,dc=local`, `o=\ xxx,dc=local` and `o=xxx\ yyy,dc=local` however current HEAD raises `ActiveLdap::DistinguishedNameInvalid` when I fed such a DN to the method `parse`.

According to the RFC document below it is allowed to have escaped spaces in DN, so I would like to send a patch to deal with them.
https://www.ietf.org/rfc/rfc4514.txt

> allowed space (' ' U+0020) to be escaped as '\ '

and

> For example, \<CN=Sam\ \> distinguishes the string
>   representation of the DN composed of one RDN consisting of the AVA
>   (the commonName (CN) value 'Sam ') from the surrounding text

Thanks,