### PR TITLE
Cwg patches

### DIFF
--- a/lib/active_ldap/attribute_methods/before_type_cast.rb
+++ b/lib/active_ldap/attribute_methods/before_type_cast.rb
@@ -13,8 +13,8 @@ module ActiveLdap
       end
 
       def get_attribute_before_type_cast(name, force_array=false)
-        name = to_real_attribute_name(name)
-
+        objectclass = @data['objectClass']
+        name = to_real_attribute_name(name) unless objectclass && objectclass.member?('extensibleObject')
         value = @data[name]
         value = [] if value.nil?
         [name, array_of(value, force_array)]

--- a/lib/active_ldap/attribute_methods/write.rb
+++ b/lib/active_ldap/attribute_methods/write.rb
@@ -16,7 +16,11 @@ module ActiveLdap
       #
       # Set the value of the attribute called by method_missing?
       def set_attribute(name, value)
-        real_name = to_real_attribute_name(name)
+        if self.classes.member? 'extensibleObject'
+          real_name = name
+        else
+          real_name = to_real_attribute_name(name)
+        end
         _dn_attribute = nil
         valid_dn_attribute = true
         begin

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1181,7 +1181,9 @@ module ActiveLdap
         _ = value # for suppress a warning on Ruby 1.9.3
       else
         new_name ||= @dn_attribute || dn_attribute_of_class
-        new_name = to_real_attribute_name(new_name)
+        unless self.classes.member? 'extensibleObject'
+          new_name = to_real_attribute_name(new_name)
+        end
         if new_name.nil?
           new_name = @dn_attribute || dn_attribute_of_class
           new_name = to_real_attribute_name(new_name)
@@ -1410,7 +1412,11 @@ module ActiveLdap
       object_classes = find_object_class_values(@ldap_data) || []
       original_attributes =
         connection.entry_attribute(object_classes).names
-      bad_attrs = original_attributes - entry_attribute.names
+      if self.classes.member? 'extensibleObject'
+        bad_attrs = []
+      else
+        bad_attrs = original_attributes - entry_attribute.names
+      end
       data = normalize_data(@data, bad_attrs)
 
       success = yield(data, ldap_data)

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1187,6 +1187,7 @@ module ActiveLdap
           new_name = to_real_attribute_name(new_name)
         end
         new_bases = bases.empty? ? nil : DN.new(*bases).to_s
+        new_value = DN.escape_value(new_value)
         dn_components = ["#{new_name}=#{new_value}",
                          new_bases,
                          self.class.base.to_s]


### PR DESCRIPTION
There are three things in this pull request:

1) Code that allows an object to be created as a different class depending on what ldap classes are in the ldap database allowing me to specialize my objects. You have have a better way to do this and if so, I’d be happy to rewrite my code to use it.

2) escape the new_value in update_dn in case it has problematic characters. I had data with commas in it that triggered this bug.

3) Add support for the extensibleObject special case.  See http://www.openldap.org/faq/data/cache/1111.html I know my implementation isn’t as clean as it could possibly be, but I got it working and hope you’ll be able to clean it up since you know the code much better than I do.