### PR TITLE
Allow object class to be determined by the ldap objectclass

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -329,7 +329,7 @@ module ActiveLdap
     class_local_attr_accessor false, :inheritable_prefix, :inheritable_base
     class_local_attr_accessor true, :dn_attribute, :scope, :sort_by, :order
     class_local_attr_accessor true, :required_classes, :recommended_classes
-    class_local_attr_accessor true, :excluded_classes
+    class_local_attr_accessor true, :excluded_classes, :subclass_map
 
     class << self
       # Hide new in Base
@@ -422,6 +422,10 @@ module ActiveLdap
         self.excluded_classes = options[:excluded_classes]
         self.sort_by = options[:sort_by]
         self.order = options[:order]
+        self.subclass_map = {}
+        if self.superclass.subclass_map and not self.required_classes == ["top"]
+          self.superclass.subclass_map[self.required_classes.map {|c| c.downcase}] = self
+        end
 
         public_class_method :new
       end
@@ -602,6 +606,10 @@ module ActiveLdap
           real_klass = self.class
         end
 
+        if attributes["objectClass"]
+          objectclasses = attributes["objectClass"].map {|c| c.downcase}
+          real_klass = real_klass.subclass_map[objectclasses] || real_klass
+        end
         obj = real_klass.allocate
         conn = options[:connection] || connection
         obj.connection = conn if conn != connection

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -663,6 +663,50 @@ class TestBase < Test::Unit::TestCase
     end
   end
 
+  class Person < ActiveLdap::Base
+    ldap_mapping dn_attribute: 'cn',
+                 prefix: 'ou=People',
+                 scope: :one,
+                 classes: ['top', 'person']
+  end
+  
+  class OrganizationalPerson < Person
+    ldap_mapping dn_attribute: 'cn',
+                 prefix: '',
+                 classes: ['top', 'person', 'organizationalPerson']
+  end                                             
+  
+  class ResidentialPerson < Person
+    ldap_mapping dn_attribute: 'cn',
+                 prefix: '',
+                 classes: ['top', 'person', 'residentialPerson']
+  end                                             
+  
+  def test_dynamic_object_class
+    make_ou("People")
+    assert_nothing_raised do
+      residential_person = ResidentialPerson.new(cn: 'John Doe',
+                                                 sn: 'Doe',
+                                                 street: '123 Main Street',
+                                                 l: 'Anytown')
+      residential_person.save!
+    end
+    assert_nothing_raised do
+      organizational_person = OrganizationalPerson.new(cn: 'Jane Smith',
+                                                       sn: 'Smith',
+                                                       title: 'General Manager')
+      organizational_person.save!
+    end
+    assert_nothing_raised do
+      people = Person.find(:all, '*')
+      classes = people.map {|person| person.class}
+      assert_equal(classes, [ResidentialPerson, OrganizationalPerson])
+      people.each do |person|
+        person.destroy
+      end
+    end
+  end
+
   def test_reload_of_not_exists_entry
     make_temporary_user do |user,|
       assert_nothing_raised do


### PR DESCRIPTION
Part one of my second attempt to submit patches.  I hope I’ve done everything right this time.

It was a bit of work thinking of a test case that didn’t use my custom schema.

If a class has subclasses which themselves have ldap classes defined,
and an object contains those ldap classes, then create an object of
that class instead of the main class.