### PR TITLE
Escaped RDN value

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -32,6 +32,7 @@
 require 'English'
 require 'thread'
 require 'erb'
+require 'set'
 
 module ActiveLdap
   # OO-interface to LDAP assuming pam/nss_ldap-style organization with
@@ -329,7 +330,8 @@ module ActiveLdap
     class_local_attr_accessor false, :inheritable_prefix, :inheritable_base
     class_local_attr_accessor true, :dn_attribute, :scope, :sort_by, :order
     class_local_attr_accessor true, :required_classes, :recommended_classes
-    class_local_attr_accessor true, :excluded_classes, :subclass_map
+    class_local_attr_accessor true, :excluded_classes
+    class_local_attr_accessor false, :sub_classes
 
     class << self
       # Hide new in Base
@@ -340,6 +342,7 @@ module ActiveLdap
         sub_class.module_eval do
           include GetTextSupport
         end
+        (self.sub_classes ||= []) << sub_class
       end
 
       # Set LDAP connection configuration up. It doesn't connect
@@ -552,6 +555,20 @@ module ActiveLdap
         defaults.first || name || to_s
       end
 
+      protected
+      def find_real_class(object_classes)
+        (sub_classes || []).each do |sub_class|
+          real_class = sub_class.find_real_class(object_classes)
+          return real_class if real_class
+        end
+
+        if object_classes.superset?(Set.new(classes))
+          self
+        else
+          nil
+        end
+      end
+
       private
       def inspect_attributes(attributes)
         inspected_attribute_names = {}
@@ -598,12 +615,19 @@ module ActiveLdap
       def instantiate(args)
         dn, attributes, options = args
         options ||= {}
-        if self.class == Class
-          klass = self.ancestors[0].to_s.split(':').last
-          real_klass = self.ancestors[0]
+
+        object_classes_raw =
+          attributes["objectClass"] ||
+          attributes["objectclass"] ||
+          []
+        if sub_classes.nil? or object_classes_raw.empty?
+          real_klass = self
         else
-          klass = self.class.to_s.split(':').last
-          real_klass = self.class
+          object_classes = Set.new
+          object_classes_raw.each do |object_class_raw|
+            object_classes << schema.object_class(object_class_raw)
+          end
+          real_klass = find_real_class(object_classes) || self
         end
 
         if attributes["objectClass"]

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -329,7 +329,7 @@ module ActiveLdap
     class_local_attr_accessor false, :inheritable_prefix, :inheritable_base
     class_local_attr_accessor true, :dn_attribute, :scope, :sort_by, :order
     class_local_attr_accessor true, :required_classes, :recommended_classes
-    class_local_attr_accessor true, :excluded_classes
+    class_local_attr_accessor true, :excluded_classes, :subclass_map
 
     class << self
       # Hide new in Base
@@ -422,6 +422,10 @@ module ActiveLdap
         self.excluded_classes = options[:excluded_classes]
         self.sort_by = options[:sort_by]
         self.order = options[:order]
+        self.subclass_map = {}
+        if self.superclass.subclass_map and not self.required_classes == ["top"]
+          self.superclass.subclass_map[self.required_classes.map {|c| c.downcase}] = self
+        end
 
         public_class_method :new
       end
@@ -602,6 +606,10 @@ module ActiveLdap
           real_klass = self.class
         end
 
+        if attributes["objectClass"]
+          objectclasses = attributes["objectClass"].map {|c| c.downcase}
+          real_klass = real_klass.subclass_map[objectclasses] || real_klass
+        end
         obj = real_klass.allocate
         conn = options[:connection] || connection
         obj.connection = conn if conn != connection

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1189,6 +1189,7 @@ module ActiveLdap
           new_name = to_real_attribute_name(new_name)
         end
         new_bases = bases.empty? ? nil : DN.new(*bases).to_s
+        new_value = DN.escape_value(new_value)
         dn_components = ["#{new_name}=#{new_value}",
                          new_bases,
                          self.class.base.to_s]

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -678,47 +678,40 @@ class TestBase < Test::Unit::TestCase
     end
   end
 
-  class Person < ActiveLdap::Base
-    ldap_mapping dn_attribute: 'cn',
-                 prefix: 'ou=People',
-                 scope: :one,
-                 classes: ['top', 'person']
-  end
-  
-  class OrganizationalPerson < Person
-    ldap_mapping dn_attribute: 'cn',
-                 prefix: '',
-                 classes: ['top', 'person', 'organizationalPerson']
-  end                                             
-  
-  class ResidentialPerson < Person
-    ldap_mapping dn_attribute: 'cn',
-                 prefix: '',
-                 classes: ['top', 'person', 'residentialPerson']
-  end                                             
-  
-  def test_dynamic_object_class
-    make_ou("People")
-    assert_nothing_raised do
-      residential_person = ResidentialPerson.new(cn: 'John Doe',
-                                                 sn: 'Doe',
-                                                 street: '123 Main Street',
-                                                 l: 'Anytown')
+  class TestInstantiate < self
+    class Person < ActiveLdap::Base
+      ldap_mapping dn_attribute: "cn",
+                   prefix: "ou=People",
+                   scope: :one,
+                   classes: ["top", "person"]
+    end
+
+    class OrganizationalPerson < Person
+      ldap_mapping dn_attribute: "cn",
+                   prefix: "",
+                   classes: ["top", "person", "organizationalPerson"]
+    end
+
+    class ResidentialPerson < Person
+      ldap_mapping dn_attribute: "cn",
+                   prefix: "",
+                   classes: ["top", "person", "residentialPerson"]
+    end
+
+    def test_sub_class
+      make_ou("People")
+      residential_person = ResidentialPerson.new(cn: "John Doe",
+                                                 sn: "Doe",
+                                                 street: "123 Main Street",
+                                                 l: "Anytown")
       residential_person.save!
-    end
-    assert_nothing_raised do
-      organizational_person = OrganizationalPerson.new(cn: 'Jane Smith',
-                                                       sn: 'Smith',
-                                                       title: 'General Manager')
+      organizational_person = OrganizationalPerson.new(cn: "Jane Smith",
+                                                       sn: "Smith",
+                                                       title: "General Manager")
       organizational_person.save!
-    end
-    assert_nothing_raised do
-      people = Person.find(:all, '*')
-      classes = people.map {|person| person.class}
-      assert_equal(classes, [ResidentialPerson, OrganizationalPerson])
-      people.each do |person|
-        person.destroy
-      end
+      people = Person.all
+      assert_equal([ResidentialPerson, OrganizationalPerson],
+                   people.collect(&:class))
     end
   end
 

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -663,6 +663,50 @@ class TestBase < Test::Unit::TestCase
     end
   end
 
+  class Person < ActiveLdap::Base
+    ldap_mapping dn_attribute: 'cn',
+                 prefix: 'ou=People',
+                 scope: :one,
+                 classes: ['top', 'person']
+  end
+  
+  class OrganizationalPerson < Person
+    ldap_mapping dn_attribute: 'cn',
+                 prefix: '',
+                 classes: ['top', 'person', 'organizationalPerson']
+  end                                             
+  
+  class ResidentialPerson < Person
+    ldap_mapping dn_attribute: 'cn',
+                 prefix: '',
+                 classes: ['top', 'person', 'residentialPerson']
+  end                                             
+  
+  def test_dynamic_object_class
+    make_ou("People")
+    assert_nothing_raised do
+      residential_person = ResidentialPerson.new(cn: 'John Doe',
+                                                 sn: 'Doe',
+                                                 street: '123 Main Street',
+                                                 l: 'Anytown')
+      residential_person.save!
+    end
+    assert_nothing_raised do
+      organizational_person = OrganizationalPerson.new(cn: 'Jane Smith',
+                                                       sn: 'Smith',
+                                                       title: 'General Manager')
+      organizational_person.save!
+    end
+    assert_nothing_raised do
+      people = Person.find(:all, '*')
+      classes = people.map {|person| person.class}
+      assert_equal(classes, [ResidentialPerson, OrganizationalPerson])
+      people.each do |person|
+        person.destroy
+      end
+    end
+  end
+
   def test_reload_of_not_exists_entry
     make_temporary_user do |user,|
       assert_nothing_raised do

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -490,6 +490,21 @@ class TestBase < Test::Unit::TestCase
     assert_equal(["one", "two", "three"].sort, ous.sort)
   end
 
+  class TestPerson < ActiveLdap::Base
+    ldap_mapping classes: ['top', 'person']
+  end
+  
+  def test_dn_attribute_with_special_characters
+    make_ou "TestPeople"
+    cn = 'Smith, John'
+    user = TestPerson.new(dn_attribute: "cn",
+                          cn: cn,
+                          sn: "Smith")
+    user.save!
+    assert_equal(cn, user.cn)
+    user.destroy
+  end
+
   def test_initialize_with_recommended_classes
     mapping = {
       :dn_attribute => "cn",


### PR DESCRIPTION
Part two of my patch.

this patch assures that it doesn’t break if there are special characters in the dn_attribute value.

I installed this patch on top of the first one that I submitted, but they are totally independent.