### PR TITLE
Allow special characters in DN values.

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1205,6 +1205,7 @@ module ActiveLdap
           new_name = to_real_attribute_name(new_name)
         end
         new_bases = bases.empty? ? nil : DN.new(*bases).to_s
+        new_value = DN.escape_value(new_value)
         dn_components = ["#{new_name}=#{new_value}",
                          new_bases,
                          self.class.base.to_s]

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -490,6 +490,22 @@ class TestBase < Test::Unit::TestCase
     assert_equal(["one", "two", "three"].sort, ous.sort)
   end
 
+  class TestSpecialCharsInRDN < self
+    class Person < ActiveLdap::Base
+      ldap_mapping classes: ['top', 'person']
+    end
+    
+    def test_dn_attribute_with_special_characters
+      make_ou "People"
+      cn = 'Smith, John'
+      user = Person.new(dn_attribute: "cn",
+                        cn: cn,
+                        sn: "Smith")
+      user.save!
+      assert_equal(cn, user.cn)
+    end
+  end
+  
   def test_initialize_with_recommended_classes
     mapping = {
       :dn_attribute => "cn",


### PR DESCRIPTION
This pull request is much simpler than the last one and hopefully you won’t have to reimplement it (or maybe even edit it).

Just allows special characters the value portion of an RDN.