### PR TITLE
Support for aliases and extensibleObjects.

### DIFF
--- a/lib/active_ldap/adapter/base.rb
+++ b/lib/active_ldap/adapter/base.rb
@@ -171,6 +171,8 @@ module ActiveLdap
         filter = parse_filter(options[:filter]) || 'objectClass=*'
         attrs = options[:attributes] || []
         scope = ensure_scope(options[:scope] || @scope)
+        derefkeys = [:never, :always, :search, :find]
+        deref = derefkeys.find_index(options[:deref]) || options[:deref] || 0
         base = options[:base]
         limit = options[:limit] || 0
         limit = nil if limit <= 0
@@ -179,7 +181,7 @@ module ActiveLdap
         base = ensure_dn_string(base)
         begin
           operation(options) do
-            yield(base, scope, filter, attrs, limit)
+            yield(base, scope, filter, attrs, limit, deref)
           end
         rescue LdapError::NoSuchObject, LdapError::InvalidDnSyntax
           # Do nothing on failure

--- a/lib/active_ldap/adapter/net_ldap.rb
+++ b/lib/active_ldap/adapter/net_ldap.rb
@@ -69,11 +69,12 @@ module ActiveLdap
         else
           paged_results_supported = false
         end
-        super(options) do |base, scope, filter, attrs, limit|
+        super(options) do |base, scope, filter, attrs, limit, deref|
           args = {
             :base => base,
             :scope => scope,
             :filter => filter,
+            :deref => deref,
             :attributes => attrs,
             :size => limit,
             :paged_searches_supported => paged_results_supported,

--- a/lib/active_ldap/attribute_methods/before_type_cast.rb
+++ b/lib/active_ldap/attribute_methods/before_type_cast.rb
@@ -13,7 +13,8 @@ module ActiveLdap
       end
 
       def get_attribute_before_type_cast(name, force_array=false)
-        name = to_real_attribute_name(name)
+        objectclass = @data['objectClass']
+        name = to_real_attribute_name(name) unless objectclass && objectclass.member?('extensibleObject')
 
         value = @data[name]
         value = [] if value.nil?

--- a/lib/active_ldap/attribute_methods/write.rb
+++ b/lib/active_ldap/attribute_methods/write.rb
@@ -16,7 +16,11 @@ module ActiveLdap
       #
       # Set the value of the attribute called by method_missing?
       def set_attribute(name, value)
-        real_name = to_real_attribute_name(name)
+        if self.classes.member? 'extensibleObject'
+          real_name = name
+        else
+          real_name = to_real_attribute_name(name)
+        end
         _dn_attribute = nil
         valid_dn_attribute = true
         begin

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1199,7 +1199,9 @@ module ActiveLdap
         _ = value # for suppress a warning on Ruby 1.9.3
       else
         new_name ||= @dn_attribute || dn_attribute_of_class
-        new_name = to_real_attribute_name(new_name)
+        unless self.classes.member? 'extensibleObject'
+          new_name = to_real_attribute_name(new_name)
+        end
         if new_name.nil?
           new_name = @dn_attribute || dn_attribute_of_class
           new_name = to_real_attribute_name(new_name)
@@ -1427,7 +1429,12 @@ module ActiveLdap
       object_classes = find_object_class_values(@ldap_data) || []
       original_attributes =
         connection.entry_attribute(object_classes).names
-      bad_attrs = original_attributes - entry_attribute.names
+      if self.classes.member? 'extensibleObject'
+        bad_attrs = []
+      else
+        bad_attrs = original_attributes - entry_attribute.names
+      end
+
       data = normalize_data(@data, bad_attrs)
 
       success = yield(data, ldap_data)

--- a/lib/active_ldap/operations.rb
+++ b/lib/active_ldap/operations.rb
@@ -23,7 +23,7 @@ module ActiveLdap
 
     module Common
       VALID_SEARCH_OPTIONS = [:attribute, :value, :filter, :prefix,
-                              :classes, :scope, :limit, :attributes,
+                              :classes, :scope, :deref, :limit, :attributes,
                               :sort_by, :order, :connection, :base, :offset]
 
       def search(options={}, &block)
@@ -57,6 +57,7 @@ module ActiveLdap
         search_options = {
           :base => _base,
           :scope => options[:scope] || scope,
+          :deref => options[:deref],
           :filter => filter,
           :limit => options[:limit],
           :attributes => requested_attributes,


### PR DESCRIPTION
This provides the ability to create and use aliases as described in 

http://www.openldap.org/faq/data/cache/1111.html

I’m not completely happy with my implementation, in particular, the makealias method in the TestLdapAlias class has to do surgery on the DNs that should be available through an API. (similar to http://net-ldap.rubyforge.org/Net/LDAP/DN.html)

Also should my Alias class need to define “attr_accessor :dn_attribute”? Seems to me that should happen anyway, but I couldn’t figure out how to do so.

Finally, I didn’t know where the best place to map deref keys to numeric values was.  I could have put it in three different places.