### PR TITLE
Make dn attribute key lookup case insensitive

### DIFF
--- a/lib/active_ldap/validations.rb
+++ b/lib/active_ldap/validations.rb
@@ -82,8 +82,8 @@ module ActiveLdap
 
     def validate_duplicated_dn_rename
       _dn_attribute = dn_attribute_with_fallback
-      original_dn_value = @ldap_data[_dn_attribute]
-      current_dn_value = @data[_dn_attribute]
+      original_dn_value = @ldap_data.find { |k, v| k.downcase == _dn_attribute.downcase }[1]
+      current_dn_value  = @data.find      { |k, v| k.downcase == _dn_attribute.downcase }[1]
       return if original_dn_value == current_dn_value
       return if original_dn_value == [current_dn_value]
 


### PR DESCRIPTION
This should fix #97.

The problem is that you can have `cn` as `dn_attribute` in your model definition and entries with `CN` (capital letters) in your directory. If loading an entry with a different DN attribute than defined in your model, saving it will fail because the library thinks we are renaming / moving the entry (we are not) and the target of that operation exists already (which it is).