### PR TITLE
bind directory server on connection check (net-ldap adapter)

### DIFF
--- a/lib/active_ldap/adapter/base.rb
+++ b/lib/active_ldap/adapter/base.rb
@@ -115,7 +115,7 @@ module ActiveLdap
         yield
       end
 
-      def connecting?
+      def connecting?(options = {})
         !@connection.nil? and !@disconnected
       end
 
@@ -624,7 +624,7 @@ module ActiveLdap
       end
 
       def reconnect_if_need(options={})
-        return if connecting?
+        return if connecting?(options)
         with_timeout(false, options) do
           reconnect(options)
         end

--- a/lib/active_ldap/adapter/net_ldap.rb
+++ b/lib/active_ldap/adapter/net_ldap.rb
@@ -67,7 +67,7 @@ module ActiveLdap
           connecting = super
           bind(options) if connecting
           connecting
-        rescue Net::LDAP::NoBindResultError, Net::LDAP::LdapError
+        rescue Net::LDAP::NoBindResultError, Net::LDAP::LdapError, AuthenticationError, NoMethodError
           return false
         end
       end

--- a/lib/active_ldap/adapter/net_ldap.rb
+++ b/lib/active_ldap/adapter/net_ldap.rb
@@ -62,6 +62,16 @@ module ActiveLdap
         end
       end
 
+      def connecting?(options={})
+        begin
+          connecting = super
+          bind(options) if connecting
+          connecting
+        rescue Net::LDAP::NoBindResultError, Net::LDAP::LdapError
+          return false
+        end
+      end
+
       def search(options={})
         use_paged_results = options[:use_paged_results]
         if use_paged_results or use_paged_results.nil?


### PR DESCRIPTION
This patch fixes connecting issue with "net-ldap" adapter by the "activeldap" side making reconnect to Directory Server after binding error.

The real problem is in "Net::LDAP::Connection" class which doesn't bind the Directory Server before operations.
As you can see, "net-ldap" has a base class "Net::LDAP" that has the same operations (search, add, modify, delete, etc) than "Net::LDAP::Connection", but the method "Net::LDAP.use_connection" used on each operation forces connect, bind and close at every call and "Net::LDAP::Connection" doesn't do it.
![net-ldap-error](https://user-images.githubusercontent.com/427446/39219956-49c650e6-4804-11e8-8615-857be4b84a92.png)

As @kou has mentioned in #112: "The problem is of net-ldap", but it still keep broken on latest version. The patch to "net-ldap" is more complicated (and "activeldap" could be changed again after it) than this simple patch and I believe this may accepted for now in order to help "activeldap" users as soon as possible.


