### PR TITLE
Use add and delete for modify

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1366,7 +1366,7 @@ module ActiveLdap
         next if v == value
 
         if klass.blank_value?(value) and
-           schema.attribute(k).binary_required?
+            schema.attribute(k).binary_required?
           value = [{'binary' => []}]
         end
         if k == _dn_attribute

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1404,7 +1404,7 @@ module ActiveLdap
     end
 
     def force_replace?(k)
-      schema.attribute(k).single_value? ||
+      schema.attribute(k).single_value? or
         schema.attribute(k).binary? # TODO: this should probably explicitly check for fields with no equality matching rule instead
     end
 

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1404,8 +1404,9 @@ module ActiveLdap
     end
 
     def force_replace?(k)
-      schema.attribute(k).single_value? or
-        schema.attribute(k).binary? # TODO: this should probably explicitly check for fields with no equality matching rule instead
+      attribute = schema.attribute(k)
+      attribute.single_value? or
+        attribute.binary? # TODO: this should probably explicitly check for fields with no equality matching rule instead
     end
 
     def collect_all_attributes(data)

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1372,7 +1372,7 @@ module ActiveLdap
         if k == _dn_attribute
           new_dn_value = value[0]
         else
-          if force_replace?(k)
+          if (v.size == 1 and value.size == 1) or force_replace?(k)
             attributes.push([:replace, k, value])
           else
             removed_values = v - value

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -447,8 +447,7 @@ class TestBase < Test::Unit::TestCase
       assert_equal({
                      :modified => true,
                      :entries => [
-                       [:delete, "cn", {"cn" => [cn]}],
-                       [:add, "cn", {"cn" => ["#{cn}!!!"]}],
+                       [:replace, "cn", {"cn" => ["#{cn}!!!"]}],
                      ],
                    },
                    detect_modify(user) {user.save})


### PR DESCRIPTION
This is my initial idea on how to tackle #142 - i.e. automatically use `add` / `delete` when appropriate instead of always using `replace`. It's still very much Work-In-Progress, open questions include:

- How to handle/detect attributes with no equality matching rule (as hinted by your comment in `collect_modified_attributes`, @kou). Currently I just always use `replace` for binary attributes. This might not be the best thing to check, it would be nicer if the matching rule could be directly checked, but I don't know how to do this.
- This is a pretty big change in behavior, maybe this should be disabled by default and only enabled through a new configuration option?
- How/where should this be documented?

Closes #142 