### PR TITLE
Add JNDI paged search support

### DIFF
--- a/lib/active_ldap/adapter/jndi.rb
+++ b/lib/active_ldap/adapter/jndi.rb
@@ -12,7 +12,6 @@ module ActiveLdap
     end
 
     class Jndi < Base
-      DEFAULT_PAGE_SIZE = 126
       METHOD = {
         :ssl => :ssl,
         :tls => :start_tls,
@@ -48,16 +47,27 @@ module ActiveLdap
 
       def search(options={}, &block)
         super(options) do |base, scope, filter, attrs, limit|
-          page_size = options.fetch :page_size, DEFAULT_PAGE_SIZE
-          use_paged_results = options.fetch(:use_paged_results) { supported_control.paged_results? }
-
+          use_paged_results = options[:use_paged_results]
+          if use_paged_results or use_paged_results.nil?
+            use_paged_results = supported_control.paged_results?
+          end
           info = {
-            :base => base, :scope => scope_name(scope), :filter => filter,
-            :attributes => attrs, :limit => limit,
-            :use_paged_results => use_paged_results, :page_size => page_size
+            base: base,
+            scope: scope_name(scope),
+            filter: filter,
+            attributes: attrs,
+            limit: limit,
+            use_paged_results: use_paged_results,
           }
-
-          execute(:search, info, base, scope, filter, attrs, limit, use_paged_results, page_size, &block)
+          options = {
+            base: base,
+            scope: scope,
+            filter: filter,
+            attributes: attrs,
+            limit: limit,
+            use_paged_results: use_paged_results,
+          }
+          execute(:search, info, options, &block)
         end
       end
 

--- a/lib/active_ldap/adapter/jndi.rb
+++ b/lib/active_ldap/adapter/jndi.rb
@@ -12,6 +12,7 @@ module ActiveLdap
     end
 
     class Jndi < Base
+      DEFAULT_PAGE_SIZE = 126
       METHOD = {
         :ssl => :ssl,
         :tls => :start_tls,
@@ -47,15 +48,16 @@ module ActiveLdap
 
       def search(options={}, &block)
         super(options) do |base, scope, filter, attrs, limit|
-          use_paged_results = options[:use_paged_results]
-          if use_paged_results || use_paged_results.nil?
-            use_paged_results = supported_control.paged_results?
-          end
+          page_size = options.fetch :page_size, DEFAULT_PAGE_SIZE
+          use_paged_results = options.fetch(:use_paged_results) { supported_control.paged_results? }
+
           info = {
             :base => base, :scope => scope_name(scope), :filter => filter,
-            :attributes => attrs, :limit => limit, :use_paged_results => use_paged_results
+            :attributes => attrs, :limit => limit,
+            :use_paged_results => use_paged_results, :page_size => page_size
           }
-          execute(:search, info, base, scope, filter, attrs, limit, use_paged_results, &block)
+
+          execute(:search, info, base, scope, filter, attrs, limit, use_paged_results, page_size, &block)
         end
       end
 

--- a/lib/active_ldap/adapter/jndi.rb
+++ b/lib/active_ldap/adapter/jndi.rb
@@ -47,11 +47,15 @@ module ActiveLdap
 
       def search(options={}, &block)
         super(options) do |base, scope, filter, attrs, limit|
+          use_paged_results = options[:use_paged_results]
+          if use_paged_results || use_paged_results.nil?
+            use_paged_results = supported_control.paged_results?
+          end
           info = {
             :base => base, :scope => scope_name(scope), :filter => filter,
-            :attributes => attrs, :limit => limit,
+            :attributes => attrs, :limit => limit, :use_paged_results => use_paged_results
           }
-          execute(:search, info, base, scope, filter, attrs, limit, &block)
+          execute(:search, info, base, scope, filter, attrs, limit, use_paged_results, &block)
         end
       end
 

--- a/lib/active_ldap/adapter/jndi_connection.rb
+++ b/lib/active_ldap/adapter/jndi_connection.rb
@@ -151,13 +151,12 @@ module ActiveLdap
           break unless use_paged_results
 
           # Find the paged search cookie
-          if res_controls = @context.get_response_controls
-            res_controls.each do |res_control|
-              next unless res_control.is_a? PagedResultsResponseControl
-
-              page_cookie = res_control.get_cookie
-              break
-            end
+          response_controls = @context.get_response_controls
+          break unless response_controls
+          response_controls.each do |response_control|
+            next unless response_control.is_a?(PagedResultsResponseControl)
+            page_cookie = response_control.get_cookie
+            break
           end
 
           break unless page_cookie

--- a/lib/active_ldap/adapter/jndi_connection.rb
+++ b/lib/active_ldap/adapter/jndi_connection.rb
@@ -207,25 +207,21 @@ module ActiveLdap
           'com.sun.jndi.ldap.read.timeout' => (@timeout * 1000).to_i.to_s,
         }
         environment = HashTable.new(environment)
-
-        @context = InitialLdapContext.new(environment, nil)
-
+        context = InitialLdapContext.new(environment, nil)
         if @method == :start_tls
-          @tls = @mod_context.extended_operation(StartTlsRequest.new)
+          @tls = context.extended_operation(StartTlsRequest.new)
           @tls.negotiate
         end
-
-        @context.add_to_environment(Context::SECURITY_AUTHENTICATION, authentication)
-
+        context.add_to_environment(Context::SECURITY_AUTHENTICATION,
+                                   authentication)
         if bind_dn
-          @context.add_to_environment(Context::SECURITY_PRINCIPAL, bind_dn)
+          context.add_to_environment(Context::SECURITY_PRINCIPAL, bind_dn)
         end
-
         if password
-          @context.add_to_environment(Context::SECURITY_CREDENTIALS, password)
+          context.add_to_environment(Context::SECURITY_CREDENTIALS, password)
         end
-
-        @context.reconnect(nil)
+        context.reconnect(nil)
+        @context = context
       end
 
       def ldap_uri

--- a/lib/active_ldap/adapter/jndi_connection.rb
+++ b/lib/active_ldap/adapter/jndi_connection.rb
@@ -110,7 +110,7 @@ module ActiveLdap
         bound?
       end
 
-      def search(base, scope, filter, attrs, limit, use_paged_results = false)
+      def search(base, scope, filter, attrs, limit, use_paged_results, page_size)
         controls = SearchControls.new
         controls.search_scope = scope
 
@@ -122,7 +122,6 @@ module ActiveLdap
         escaped_base = escape_dn(base)
         if use_paged_results
           # https://devdocs.io/openjdk~8/javax/naming/ldap/pagedresultscontrol
-          page_size = 5
           page_cookie = nil
           @context.set_request_controls([PagedResultsControl.new(page_size, Control::CRITICAL)])
         end
@@ -154,7 +153,6 @@ module ActiveLdap
           break unless page_cookie
 
           # Set paged results control so we can keep getting results.
-          puts "==> found paged results cookie: #{page_cookie}"
           @context.set_request_controls(
             [PagedResultsControl.new(page_size, page_cookie, Control::CRITICAL)]
           )

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -3,7 +3,17 @@ require 'al-test-utils'
 class TestFind < Test::Unit::TestCase
   include AlTestUtils
 
-  priority :must
+  def test_find_paged
+    # The default page size is 126.
+    n_users = 127
+    uids = n_users.times.collect do
+      user, _password = make_temporary_user
+      user.uid
+    end
+    assert_equal(uids.sort,
+                 @user_class.find(:all).collect(&:uid).sort)
+  end
+
   def test_find_with_dn
     make_temporary_user do |user,|
       assert_equal(user.dn, @user_class.find(user.dn).dn)
@@ -11,7 +21,6 @@ class TestFind < Test::Unit::TestCase
     end
   end
 
-  priority :normal
   def test_find_with_special_value_prefix
     # \2C == ','
     make_ou("a\\2Cb,ou=Users")


### PR DESCRIPTION
Closes #169 

I was able to demonstrate paged searching using the [Forum Systems Online LDAP Test Server](http://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/)

```ruby
base_dir = File.expand_path(File.dirname(__FILE__))
top_dir = File.expand_path(File.join(base_dir, ".."))
lib_dir = File.join(top_dir, "lib")
$LOAD_PATH.unshift(File.join __dir__, 'lib')

require 'active_ldap'

class Person < ActiveLdap::Base
  setup_connection host: 'ldap.forumsys.com',
                   port: 389,
                   base: 'dc=example,dc=com',
                   method: :plain,
                   bind_dn: 'cn=read-only-admin,dc=example,dc=com',
                   password: 'password',
                   adapter: 'jndi'

  ldap_mapping dn_attribute: 'uid',
               prefix: '',
               classes: %w[person]
end

puts Person.all(filter: { cn: '*' }, attributes: %w[cn]).map(&:cn)
# ==> found paged results cookie: $
# ==> found paged results cookie: 0
# ==> found paged results cookie: 6
# Isaac Newton
# Albert Einstein
# Nikola Tesla
# Galileo Galilei
# Leonhard Euler
# Carl Friedrich Gauss
# Bernhard Riemann
# Euclid
# read-only-admin
# Test
# Marie Curie
# Alfred Nobel
# Robert Boyle
# Louis Pasteur
# No Group
# FS Training
# FS Training
```