### PR TITLE
Do not use paged searching when limit is 1

### DIFF
--- a/lib/active_ldap/adapter/base.rb
+++ b/lib/active_ldap/adapter/base.rb
@@ -181,7 +181,7 @@ module ActiveLdap
         limit = nil if limit <= 0
         use_paged_results = options[:use_paged_results]
         if use_paged_results or use_paged_results.nil?
-          use_paged_results = supported_control.paged_results?
+          use_paged_results = limit.to_i != 1 && supported_control.paged_results?
         end
         search_options = {
           base: base,

--- a/lib/active_ldap/adapter/base.rb
+++ b/lib/active_ldap/adapter/base.rb
@@ -181,7 +181,7 @@ module ActiveLdap
         limit = nil if limit <= 0
         use_paged_results = options[:use_paged_results]
         if use_paged_results or use_paged_results.nil?
-          use_paged_results = limit.to_i != 1 && supported_control.paged_results?
+          use_paged_results = limit != 1 && supported_control.paged_results?
         end
         search_options = {
           base: base,


### PR DESCRIPTION
Fixes #172

```
Loading test environment (Rails 4.2.11.1)
irb: warn: can't alias context from irb_context.
jruby-9.2.11.0 :001 > Person.all '(uid=*)'
Attempting to reconnect
  LDAP: connect (1.0ms) {:uri=>"ldap://localhost:13891", :with_start_tls=>false}
  LDAP: bind (54.8ms) {:dn=>"<REDACTED>"}
Bound to ldap://localhost:13891 by simple as <REDACTED>
  LDAP: search (12.5ms) {:base=>"", :scope=>:base, :filter=>"objectClass=*", :attributes=>["supportedControl"], :limit=>1, :use_paged_results=>false, :page_size=>500}
  LDAP: search (87.9ms) {:base=>"ou=people,dc=weill,dc=cornell,dc=edu", :scope=>:one, :filter=>"(&(uid=*)(&(objectClass=inetOrgPerson)(objectClass=weillCornellEduPerson)))", :attributes=>["*", "isMemberOf", "createTimestamp", "modifyTimestamp", "creatorsName", "modifiersName", "objectClass"], :limit=>nil, :use_paged_results=>true, :page_size=>500}
  LDAP: search (3.1ms) {:base=>"", :scope=>:base, :filter=>"objectClass=*", :attributes=>["subschemaSubentry"], :limit=>1, :use_paged_results=>false, :page_size=>500}
  LDAP: search (63.3ms) {:base=>"cn=schema", :scope=>:base, :filter=>"(objectClass=subschema)", :attributes=>["objectClasses", "attributeTypes", "matchingRules", "matchingRuleUse", "dITStructureRules", "dITContentRules", "nameForms", "ldapSyntaxes"], :limit=>1, :use_paged_results=>false, :page_size=>500}
[
    [ 0] #<Person objectClass:<top, eduPerson, inetOrgPerson, ...
```