### PR TITLE
Use javax.naming.ldap.LdapName to escape DNs with JNDI

### DIFF
--- a/lib/active_ldap/adapter/jndi_connection.rb
+++ b/lib/active_ldap/adapter/jndi_connection.rb
@@ -134,10 +134,8 @@ module ActiveLdap
         else
           @context.set_request_controls([])
         end
-
-        escaped_base = escape_dn(base)
         loop do
-          @context.search(escaped_base, filter, controls).each do |search_result|
+          @context.search(escape_dn(base), filter, controls).each do |search_result|
             yield(build_raw_search_result(search_result))
           end
 
@@ -166,26 +164,23 @@ module ActiveLdap
         records.each do |record|
           attributes.put(record.to_java_attribute)
         end
-        escaped_dn = escape_dn(dn)
         @context.set_request_controls([])
-        @context.create_subcontext(escaped_dn, attributes)
+        @context.create_subcontext(escape_dn(dn), attributes)
       end
 
       def modify(dn, records)
-        escaped_dn = escape_dn(dn)
         items = records.collect(&:to_java_modification_item)
         @context.set_request_controls([])
-        @context.modify_attributes(escaped_dn, items.to_java(ModificationItem))
+        @context.modify_attributes(escape_dn(dn), items.to_java(ModificationItem))
       end
 
       def modify_rdn(dn, new_rdn, delete_old_rdn)
-        escaped_dn = escape_dn(dn)
         # should use mutex
         delete_rdn_key = "java.naming.ldap.deleteRDN"
         @context.set_request_controls([])
         begin
           @context.add_to_environment(delete_rdn_key, delete_old_rdn.to_s)
-          @context.rename(escaped_dn, new_rdn)
+          @context.rename(escape_dn(dn), escape_dn(new_rdn))
         ensure
           @context.remove_from_environment(delete_rdn_key)
         end
@@ -230,34 +225,9 @@ module ActiveLdap
       end
 
       def escape_dn(dn)
-        parsed_dn = nil
-        begin
-          parsed_dn = DN.parse(dn)
-        rescue DistinguishedNameInvalid
-          return dn
-        end
-
-        escaped_rdns = parsed_dn.rdns.collect do |rdn|
-          escaped_rdn_strings = rdn.collect do |key, value|
-            escaped_value = DN.escape_value(value)
-            # We may need to escape the followings too:
-            #   * ,
-            #   * =
-            #   * +
-            #   * <
-            #   * >
-            #   * #
-            #   * ;
-            #
-            # See javax.naming.ldap.Rdn.unescapeValue()
-            escaped_value = escaped_value.gsub(/\\\\/) do
-              "\\5C"
-            end
-            "#{key}=#{escaped_value}"
-          end
-          escaped_rdn_strings.join("+")
-        end
-        escaped_rdns.join(",")
+        javax.naming.ldap.LdapName.new(dn)
+      rescue Java::JavaxNaming::InvalidNameException
+        dn
       end
 
       def build_paged_results_control(page_size, page_cookie=nil)

--- a/lib/active_ldap/adapter/jndi_connection.rb
+++ b/lib/active_ldap/adapter/jndi_connection.rb
@@ -226,7 +226,7 @@ module ActiveLdap
 
       def escape_dn(dn)
         javax.naming.ldap.LdapName.new(dn)
-      rescue Java::JavaxNaming::InvalidNameException
+      rescue Java::JavaLang::IllegalArgumentException, Java::JavaxNaming::InvalidNameException
         dn
       end
 

--- a/lib/active_ldap/adapter/jndi_connection.rb
+++ b/lib/active_ldap/adapter/jndi_connection.rb
@@ -134,8 +134,11 @@ module ActiveLdap
         else
           @context.set_request_controls([])
         end
+
+        escaped_base = escape_dn(base)
+
         loop do
-          @context.search(escape_dn(base), filter, controls).each do |search_result|
+          @context.search(escaped_base, filter, controls).each do |search_result|
             yield(build_raw_search_result(search_result))
           end
 

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -383,15 +383,18 @@ class TestBase < Test::Unit::TestCase
     end
   end
 
-  def test_set_dn_with_unnormalized_dn_attribute_with_forward_slash
+  def test_set_dn_with_unnormalized_dn_attribute_with_forward_slash 
     make_temporary_user do |user,|
-      assert_not_equal(user.dn.to_s, 'uid=temp/user1,ou=Users,ou=test,dc=example,dc=org')
+      new_dn = "uid=temp/user1,#{user.class.base}"
+      assert_not_equal(user.dn.to_s, new_dn)
+
       user.uid = 'temp/user1'
-      assert_equal(user.dn.to_s, 'uid=temp/user1,ou=Users,ou=test,dc=example,dc=org')
+      assert_equal(user.dn.to_s, new_dn)
+
       assert_true(user.save!)
       assert_true(user.class.find(user.uid).update_attributes!(gidNumber: 100069))
     end
-  end
+ end
 
   def test_destroy_with_empty_base_and_prefix_of_class
     make_temporary_user do |user,|

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -383,6 +383,16 @@ class TestBase < Test::Unit::TestCase
     end
   end
 
+  def test_set_dn_with_unnormalized_dn_attribute_with_forward_slash
+    make_temporary_user do |user,|
+      assert_not_equal(user.dn.to_s, 'uid=temp/user1,ou=Users,ou=test,dc=example,dc=org')
+      user.uid = 'temp/user1'
+      assert_equal(user.dn.to_s, 'uid=temp/user1,ou=Users,ou=test,dc=example,dc=org')
+      assert_true(user.save!)
+      assert_true(user.class.find(user.uid).update_attributes!(gidNumber: 100069))
+    end
+  end
+
   def test_destroy_with_empty_base_and_prefix_of_class
     make_temporary_user do |user,|
       base = user.class.base


### PR DESCRIPTION
I noticed an issue saving entries that have forward slashes in their DN.

```
Error: test_set_dn_with_unnormalized_dn_attribute_with_forward_slash(TestBase): ActiveLdap::EntryNotFound: Couldn't find User: DN: temp/user1: filter: ["uid", "temp/user1"]
```

I found this [SO post](https://stackoverflow.com/questions/11690529/forward-slashes-in-the-names-returned-by-jndi-query-to-ldap-server) which pointed my to `javax.naming.ldap.LdapName`

> The LDAP name parser in the JDK is conservative with respect to quoting rules, but it nevertheless produces "correct" names. Also, remember that the names of entries returned by NamingEnumerations are composite names that can be passed back to the Context and DirContext methods. So, if the name contains a character that conflicts with the composite name syntax (such as the forward slash character "/"), then the LDAP provider will provide an encoding to ensure that the slash character will be treated as part of the LDAP name rather than as a composite name separator.
- https://docs.oracle.com/javase/tutorial/jndi/ldap/faq.html#20