### PR TITLE
Respect use_paged_results configuration option

### DIFF
--- a/lib/active_ldap/adapter/base.rb
+++ b/lib/active_ldap/adapter/base.rb
@@ -180,7 +180,8 @@ module ActiveLdap
         limit = options[:limit] || 0
         limit = nil if limit <= 0
         use_paged_results = options[:use_paged_results]
-        if use_paged_results or use_paged_results.nil?
+        use_paged_results = @use_paged_results if options[:use_paged_results].nil?
+        if use_paged_results
           use_paged_results = limit != 1 && supported_control.paged_results?
         end
         search_options = {

--- a/lib/active_ldap/adapter/base.rb
+++ b/lib/active_ldap/adapter/base.rb
@@ -180,7 +180,7 @@ module ActiveLdap
         limit = options[:limit] || 0
         limit = nil if limit <= 0
         use_paged_results = options[:use_paged_results]
-        use_paged_results = @use_paged_results if options[:use_paged_results].nil?
+        use_paged_results = @use_paged_results if use_paged_results.nil?
         if use_paged_results
           use_paged_results = limit != 1 && supported_control.paged_results?
         end


### PR DESCRIPTION
This allows turning off paged search results using the global
configuration option.