### PR TITLE
Make logs bold using option hash instead of a positional boolean

### DIFF
--- a/lib/active_ldap/log_subscriber.rb
+++ b/lib/active_ldap/log_subscriber.rb
@@ -30,10 +30,10 @@ module ActiveLdap
       inspected_info = info.inspect
 
       if odd?
-        name = color(name, CYAN, true)
-        inspected_info = color(inspected_info, nil, true)
+        name = color(name, CYAN, bold: true)
+        inspected_info = color(inspected_info, nil, bold: true)
       else
-        name = color(name, MAGENTA, true)
+        name = color(name, MAGENTA, bold: true)
       end
 
       debug "  #{name} #{inspected_info}"

--- a/lib/active_ldap/log_subscriber.rb
+++ b/lib/active_ldap/log_subscriber.rb
@@ -29,11 +29,19 @@ module ActiveLdap
       name = 'LDAP: %s (%.1fms)' % [label, event.duration]
       inspected_info = info.inspect
 
+      formatting_options = 
+        if ActiveSupport.version >= Gem::Version.new('7.1.0')
+          { bold: true }
+        else
+          # Fallback for ActiveSupport < 7.1.0
+          true
+        end
+
       if odd?
-        name = color(name, CYAN, bold: true)
-        inspected_info = color(inspected_info, nil, bold: true)
+        name = color(name, CYAN, formatting_options)
+        inspected_info = color(inspected_info, nil, formatting_options)
       else
-        name = color(name, MAGENTA, bold: true)
+        name = color(name, MAGENTA, formatting_options)
       end
 
       debug "  #{name} #{inspected_info}"


### PR DESCRIPTION
This updates the way logs are formatted as bold text, as the old way is deprecated and will be removed in Rails 7.2, see [here](https://github.com/rails/rails/commit/6016f9ef3190489d87c2249d6a150f5a4d1b0753).