### PR TITLE
Use attribute_method_matchers instead of attribute_method_patterns with ActiveModel >= 7.1.0

### DIFF
--- a/lib/active_ldap/attribute_methods.rb
+++ b/lib/active_ldap/attribute_methods.rb
@@ -7,8 +7,17 @@ module ActiveLdap
       target_names = entry_attribute.all_names
       target_names -= ['objectClass', 'objectClass'.underscore]
       super + target_names.uniq.collect do |attr|
-        self.class.attribute_method_matchers.collect do |matcher|
-          :"#{matcher.prefix}#{attr}#{matcher.suffix}"
+        method_patterns = 
+          if self.class.respond_to?(:attribute_method_patterns)
+            # Support for ActiveModel >= 7.1.0
+            self.class.attribute_method_patterns
+          else
+            # Support for ActiveModel < 7.1.0
+            self.class.attribute_method_matchers
+          end
+        
+        method_patterns.collect do |pattern|
+          pattern.method_name(attr).to_sym
         end
       end.flatten
     end


### PR DESCRIPTION
In ActiveModel 7.1.0 `attribute_method_patterns` was renamed to `attribute_method_matchers`, see https://github.com/rails/rails/pull/44367. As this method is used in `AL::AttributeMethods#methods`, this caused errors when calling `methods` on an instance of `AL::Base`. 

This PR causes `methods` to always use `attribute_method_matchers` if it exists. If not, `attribute_method_patterns` is called as a fallback to support ActiveModel versions older than 7.1.0.

I also changed the creation of the attribute methods after that, as the `AM::AttributeMethodMatcher` Class already has a method for that: `method_name(attr)`.
