### PR TITLE
fix net_ldap paged search

### DIFF
--- a/lib/active_ldap/adapter/net_ldap.rb
+++ b/lib/active_ldap/adapter/net_ldap.rb
@@ -78,7 +78,7 @@ module ActiveLdap
             filter: search_options[:filter],
             attributes: search_options[:attributes],
             size: search_options[:limit],
-            paged_searcheds_supported: search_options[:paged_results_supported],
+            paged_searches_supported: search_options[:use_paged_results],
           }
           execute(:search, info, args) do |entry|
             attributes = {}


### PR DESCRIPTION
Two errors that prevented proper support for paged search:
- Wrong key name to fetch value from the search_options hash
- Typo in key for net-ldap search args