### PR TITLE
Support rails 7.0

### DIFF
--- a/lib/active_ldap/railtie.rb
+++ b/lib/active_ldap/railtie.rb
@@ -7,7 +7,7 @@ Locale.init(:driver => :cgi)
 module ActiveLdap
   class Railtie < Rails::Railtie
     initializer "active_ldap.deprecator", before: :load_environment_config do |app|
-      app.deprecators[:active_ldap] = ActiveLdap.deprecator
+      app.deprecators[:active_ldap] = ActiveLdap.deprecator if defined?(app.deprecators)
     end
 
     initializer "active_ldap.setup_connection" do

--- a/lib/active_ldap/railtie.rb
+++ b/lib/active_ldap/railtie.rb
@@ -7,7 +7,7 @@ Locale.init(:driver => :cgi)
 module ActiveLdap
   class Railtie < Rails::Railtie
     initializer "active_ldap.deprecator", before: :load_environment_config do |app|
-      app.deprecators[:active_ldap] = ActiveLdap.deprecator if defined?(app.deprecators)
+      app.deprecators[:active_ldap] = ActiveLdap.deprecator if app.respond_to?(:deprecators)
     end
 
     initializer "active_ldap.setup_connection" do


### PR DESCRIPTION
Link deprecator to Rails.application when feature exists.

`Rails.application.deprecators` is only available on Rails 7.1+