### PR TITLE
Fix deprecated use of ActiveSupport::Deprecation

### DIFF
--- a/lib/active_ldap.rb
+++ b/lib/active_ldap.rb
@@ -43,6 +43,8 @@ require 'active_ldap/helper'
 require 'active_ldap/validations'
 require 'active_ldap/callbacks'
 
+require 'active_ldap/deprecator'
+
 
 ActiveLdap::Base.class_eval do
   include ActiveLdap::Persistence

--- a/lib/active_ldap/associations.rb
+++ b/lib/active_ldap/associations.rb
@@ -67,7 +67,7 @@ module ActiveLdap
           if foreign_key_name
             message = _(":foreign_key belongs_to(:many) option is " \
                         "deprecated since 1.1.0. Use :primary_key instead.")
-            ActiveSupport::Deprecation.warn(message)
+            ActiveLdap.deprecator.warn(message)
             opts[:primary_key_name] ||= foreign_key_name
           end
           opts[:primary_key_name] ||= dn_attribute
@@ -135,7 +135,7 @@ module ActiveLdap
               !new.have_attribute?(primary_key_name)
             message = _(":primary_key and :foreign_key has_many options are " \
                         "inverted their mean since 1.1.0. Please invert them.")
-            ActiveSupport::Deprecation.warn(message)
+            ActiveLdap.deprecator.warn(message)
             opts[:foreign_key_name] = primary_key_name
             opts[:primary_key_name] = foreign_key_name
           end

--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -55,7 +55,7 @@ module ActiveLdap
           _("ActiveLdap::ConnectionNotEstablished has been deprecated " \
             "since 1.1.0. " \
             "Please use ActiveLdap::ConnectionNotSetup instead.")
-        ActiveSupport::Deprecation.warn(message)
+        ActiveLdap.deprecator.warn(message)
         const_set("ConnectionNotEstablished", ConnectionNotSetup)
         ConnectionNotEstablished
       else
@@ -391,7 +391,7 @@ module ActiveLdap
           _("ActiveLdap::Base.establish_connection has been deprecated " \
             "since 1.1.0. " \
             "Please use ActiveLdap::Base.setup_connection instead.")
-        ActiveSupport::Deprecation.warn(message)
+        ActiveLdap.deprecator.warn(message)
         setup_connection(config)
       end
 

--- a/lib/active_ldap/callbacks.rb
+++ b/lib/active_ldap/callbacks.rb
@@ -26,7 +26,7 @@ module ActiveLdap
       def method_added(meth)
         super
         if CALLBACKS.include?(meth.to_sym)
-          ActiveSupport::Deprecation.warn("Base##{meth} has been deprecated, please use Base.#{meth} :method instead", caller[0,1])
+          ActiveLdap.deprecator.warn("Base##{meth} has been deprecated, please use Base.#{meth} :method instead", caller[0,1])
           send(meth.to_sym, meth.to_sym)
         end
       end

--- a/lib/active_ldap/configuration.rb
+++ b/lib/active_ldap/configuration.rb
@@ -137,7 +137,7 @@ module ActiveLdap
             if key == :ldap_scope
               message = _(":ldap_scope configuration option is deprecated. " \
                           "Use :scope instead.")
-              ActiveSupport::Deprecation.warn(message)
+              ActiveLdap.deprecator.warn(message)
             end
             target.scope = value
             configuration[:scope] = value

--- a/lib/active_ldap/connection.rb
+++ b/lib/active_ldap/connection.rb
@@ -97,7 +97,7 @@ module ActiveLdap
         if config.has_key?(:ldap_scope)
           message = _(":ldap_scope connection option is deprecated. " \
                       "Use :scope instead.")
-          ActiveSupport::Deprecation.warn(message)
+          ActiveLdap.deprecator.warn(message)
           config[:scope] ||= config.delete(:ldap_scope)
         end
         config = remove_connection_related_configuration(config)
@@ -156,7 +156,7 @@ module ActiveLdap
           _("ActiveLdap::Connection.establish_connection has been deprecated " \
             "since 1.1.0. " \
             "Please use ActiveLdap::Connection.setup_connection instead.")
-        ActiveSupport::Deprecation.warn(message)
+        ActiveLdap.deprecator.warn(message)
         setup_connection(config)
       end
 
@@ -216,7 +216,7 @@ module ActiveLdap
         _("ActiveLdap::Connection#establish_connection has been deprecated " \
           "since 1.1.0. " \
           "Please use ActiveLdap::Connection#setup_connection instead.")
-      ActiveSupport::Deprecation.warn(message)
+      ActiveLdap.deprecator.warn(message)
       setup_connection(config)
     end
 

--- a/lib/active_ldap/deprecator.rb
+++ b/lib/active_ldap/deprecator.rb
@@ -1,5 +1,5 @@
-  module ActiveLdap
-    def self.deprecator
-      @deprecator ||= ActiveSupport::Deprecation.new("7.1.0", "ActiveLdap")
-    end
+module ActiveLdap
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("7.1.0", "ActiveLdap")
   end
+end

--- a/lib/active_ldap/deprecator.rb
+++ b/lib/active_ldap/deprecator.rb
@@ -1,0 +1,5 @@
+  module ActiveLdap
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new("7.1.0", "ActiveLdap")
+    end
+  end

--- a/lib/active_ldap/operations.rb
+++ b/lib/active_ldap/operations.rb
@@ -65,7 +65,7 @@ module ActiveLdap
         if options.has_key?(:ldap_scope)
           message = _(":ldap_scope search option is deprecated. " \
                       "Use :scope instead.")
-          ActiveSupport::Deprecation.warn(message)
+          ActiveLdap.deprecator.warn(message)
           options[:scope] ||= options[:ldap_scope]
         end
         search_options = {

--- a/lib/active_ldap/railtie.rb
+++ b/lib/active_ldap/railtie.rb
@@ -37,5 +37,10 @@ module ActiveLdap
         include ActiveLdap::Railties::ControllerRuntime
       end
     end
+
+    initializer "active_ldap.deprecator", :before => "active_ldap.setup_connection" do |app|
+      require "active_ldap/deprecator"
+      app.deprecators[:active_ldap] = ActiveLdap.deprecator
+    end
   end
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -134,7 +134,7 @@ EOX
   end
 
   def test_belongs_to_foreign_key_before_1_1_0
-    ActiveSupport::Deprecation.silence do
+    ActiveLdap.deprecator.silence do
       @group_class.belongs_to :related_users, :many => "seeAlso",
                               :foreign_key => "dn"
     end


### PR DESCRIPTION
Singleton use of ActiveSupport::Deprecation (e.g. `ActiveSupport::Deprecation.warn()`) was deprecated with the release of Rails 7.1 (https://guides.rubyonrails.org/7_1_release_notes.html#active-support-deprecations) and removed in Rails 7.2 (https://guides.rubyonrails.org/7_2_release_notes.html#active-support-removals). As a gem you are now expected to have your own instance of ActiveSupport::Deprecation and use this instead.

This PR introduces a deprecator for ActiveLdap with `ActiveLdap.deprecator` and updates all occurences of singleton use to instead use the deprecator.

Of course open for feedback or any changes needed to get this merged.