### PR TITLE
Remove deprecated way of specifying :primary_key and :foreign_key on has_many

### DIFF
--- a/lib/active_ldap/associations.rb
+++ b/lib/active_ldap/associations.rb
@@ -103,10 +103,6 @@ module ActiveLdap
       #   has_many :primary_members, :class_name => "User",
       #            :primary_key => "gidNumber", # Group#gidNumber
       #            :foreign_key => "gidNumber"  # User#gidNumber
-      #            ## deprecated since 1.1.0. Those options
-      #            ## are inverted.
-      #            # :primary_key => "gidNumber", # User#gidNumber
-      #            # :foreign_key => "gidNumber"  # Group#gidNumber
       #   has_many :members, :class_name => "User",
       #            :wrap => "memberUid" # Group#memberUid
       def has_many(association_id, options = {})
@@ -130,15 +126,6 @@ module ActiveLdap
           association_class = Association::HasMany
           primary_key_name = opts[:primary_key_name]
           foreign_key_name = opts[:foreign_key_name]
-          if primary_key_name != foreign_key_name and
-              primary_key_name != "dn" and
-              !new.have_attribute?(primary_key_name)
-            message = _(":primary_key and :foreign_key has_many options are " \
-                        "inverted their mean since 1.1.0. Please invert them.")
-            ActiveLdap.deprecator.warn(message)
-            opts[:foreign_key_name] = primary_key_name
-            opts[:primary_key_name] = foreign_key_name
-          end
         end
 
         association_accessor(association_id) do |target|

--- a/po/en/active-ldap.po
+++ b/po/en/active-ldap.po
@@ -3575,12 +3575,6 @@ msgid ""
 "primary_key instead."
 msgstr ""
 
-#: lib/active_ldap/associations.rb:136
-msgid ""
-":primary_key and :foreign_key has_many options are inverted their mean since "
-"1.1.0. Please invert them."
-msgstr ""
-
 #: lib/active_ldap/ldif.rb:396
 msgid "version spec is missing"
 msgstr ""

--- a/po/ja/active-ldap.po
+++ b/po/ja/active-ldap.po
@@ -3590,14 +3590,6 @@ msgstr ""
 "1.1.0からbelongs_to(:many)の:foreign_keyオプションは非推奨になりました。代わ"
 "りに:primary_keyを使ってください。"
 
-#: lib/active_ldap/associations.rb:136
-msgid ""
-":primary_key and :foreign_key has_many options are inverted their mean since "
-"1.1.0. Please invert them."
-msgstr ""
-"1.1.0からhas_manyの:primary_keyと:foreign_keyオプションの意味が反対になりまし"
-"た。オプションの値を入れかえてください。"
-
 #: lib/active_ldap/ldif.rb:396
 msgid "version spec is missing"
 msgstr "バージョン指定がありません"


### PR DESCRIPTION
This PR removes functionality that was deprecated in version 1.1.0. With the deprecation, the meaning of `:primary_key` and `foreign_key` on a hasMany association was flipped.

Part of #205.