### PR TITLE
Remove deprecated ConnectionNotEstablished error

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -48,20 +48,6 @@ module ActiveLdap
 
   class << self
     include GetTextSupport
-    def const_missing(id)
-      case id
-      when :ConnectionNotEstablished
-        message =
-          _("ActiveLdap::ConnectionNotEstablished has been deprecated " \
-            "since 1.1.0. " \
-            "Please use ActiveLdap::ConnectionNotSetup instead.")
-        ActiveLdap.deprecator.warn(message)
-        const_set("ConnectionNotEstablished", ConnectionNotSetup)
-        ConnectionNotEstablished
-      else
-        super
-      end
-    end
   end
 
   class Error < StandardError

--- a/po/en/active-ldap.po
+++ b/po/en/active-ldap.po
@@ -3763,12 +3763,6 @@ msgstr ""
 msgid "Show version"
 msgstr ""
 
-#: lib/active_ldap/base.rb:53
-msgid ""
-"ActiveLdap::ConnectionNotEstablished has been deprecated since 1.1.0. Please "
-"use ActiveLdap::ConnectionNotSetup instead."
-msgstr ""
-
 #: lib/active_ldap/base.rb:131
 msgid "invalid distinguished name (DN) to parse: %s"
 msgstr ""

--- a/po/ja/active-ldap.po
+++ b/po/ja/active-ldap.po
@@ -3780,14 +3780,6 @@ msgstr "このメッセージを表示します"
 msgid "Show version"
 msgstr "バージョンを表示します"
 
-#: lib/active_ldap/base.rb:53
-msgid ""
-"ActiveLdap::ConnectionNotEstablished has been deprecated since 1.1.0. Please "
-"use ActiveLdap::ConnectionNotSetup instead."
-msgstr ""
-"1.1.0からActiveLdap::ConnectionNotEstablishedは非推奨になりました。代わりに"
-"ActiveLdap::ConnectionNotSetupを使ってください。"
-
 #: lib/active_ldap/base.rb:131
 msgid "invalid distinguished name (DN) to parse: %s"
 msgstr "構文解析できない不正な識別名(DN)です: %s"


### PR DESCRIPTION
`ActiveLdap::ConnectionNotEstablished` was replaced by `ActiveLdap::ConnectionNotSetup` with version 1.1.0. This PR removes the deprecated error for good.

Part of #205.