### PR TITLE
Remove all establish_connection methods

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -384,17 +384,6 @@ module ActiveLdap
         nil
       end
 
-      # establish_connection is deprecated since 1.1.0. Please use
-      # setup_connection() instead.
-      def establish_connection(config=nil)
-        message =
-          _("ActiveLdap::Base.establish_connection has been deprecated " \
-            "since 1.1.0. " \
-            "Please use ActiveLdap::Base.setup_connection instead.")
-        ActiveLdap.deprecator.warn(message)
-        setup_connection(config)
-      end
-
       def create(attributes=nil, &block)
         if attributes.is_a?(Array)
           attributes.collect {|attrs| create(attrs, &block)}

--- a/lib/active_ldap/connection.rb
+++ b/lib/active_ldap/connection.rb
@@ -151,15 +151,6 @@ module ActiveLdap
         define_configuration(key, merge_configuration(config))
       end
 
-      def establish_connection(config=nil)
-        message =
-          _("ActiveLdap::Connection.establish_connection has been deprecated " \
-            "since 1.1.0. " \
-            "Please use ActiveLdap::Connection.setup_connection instead.")
-        ActiveLdap.deprecator.warn(message)
-        setup_connection(config)
-      end
-
       # Return the schema object
       def schema
         connection.schema
@@ -209,15 +200,6 @@ module ActiveLdap
 
       remove_connection
       self.class.define_configuration(dn, config)
-    end
-
-    def establish_connection(config=nil)
-      message =
-        _("ActiveLdap::Connection#establish_connection has been deprecated " \
-          "since 1.1.0. " \
-          "Please use ActiveLdap::Connection#setup_connection instead.")
-      ActiveLdap.deprecator.warn(message)
-      setup_connection(config)
     end
 
     def remove_connection

--- a/po/en/active-ldap.po
+++ b/po/en/active-ldap.po
@@ -3801,12 +3801,6 @@ msgstr ""
 msgid "not implemented: %s"
 msgstr ""
 
-#: lib/active_ldap/base.rb:382
-msgid ""
-"ActiveLdap::Base.establish_connection has been deprecated since 1.1.0. "
-"Please use ActiveLdap::Base.setup_connection instead."
-msgstr ""
-
 #: lib/active_ldap/base.rb:463
 msgid "scope '%s' must be a Symbol"
 msgstr ""
@@ -3855,12 +3849,6 @@ msgstr ""
 
 #: lib/active_ldap/connection.rb:98
 msgid ":ldap_scope connection option is deprecated. Use :scope instead."
-msgstr ""
-
-#: lib/active_ldap/connection.rb:156
-msgid ""
-"ActiveLdap::Connection.establish_connection has been deprecated since 1.1.0. "
-"Please use ActiveLdap::Connection.setup_connection instead."
 msgstr ""
 
 #: lib/active_ldap/connection.rb:236

--- a/po/ja/active-ldap.po
+++ b/po/ja/active-ldap.po
@@ -3820,14 +3820,6 @@ msgstr "%sは未知の属性です"
 msgid "not implemented: %s"
 msgstr "未実装です: %s"
 
-#: lib/active_ldap/base.rb:382
-msgid ""
-"ActiveLdap::Base.establish_connection has been deprecated since 1.1.0. "
-"Please use ActiveLdap::Base.setup_connection instead."
-msgstr ""
-"1.1.0からActiveLdap::Base.establish_connectionは非推奨になりました。代わりに"
-"ActiveLdap::Base.setup_connectionを使ってください。"
-
 #: lib/active_ldap/base.rb:463
 msgid "scope '%s' must be a Symbol"
 msgstr "スコープ'%s'はシンボルでなければいけません"
@@ -3882,14 +3874,6 @@ msgstr "属性 %s: ハッシュはひとつのキー・値のペアしか持っ�
 msgid ":ldap_scope connection option is deprecated. Use :scope instead."
 msgstr ""
 ":ldap_scope接続オプションは廃止予定です。代わりに:scopeを使ってください。"
-
-#: lib/active_ldap/connection.rb:156
-msgid ""
-"ActiveLdap::Connection.establish_connection has been deprecated since 1.1.0. "
-"Please use ActiveLdap::Connection.setup_connection instead."
-msgstr ""
-"1.1.0からActiveLdap::Connection.establish_connectionは非推奨になりました。代"
-"わりにActiveLdap::Connection.setup_connectionを使ってください。"
 
 #: lib/active_ldap/connection.rb:236
 msgid "since 1.1.0. "


### PR DESCRIPTION
`ActiveLdap::Base.establish_connection`, `ActiveLdap::Connection.establish_connection` and `ActiveLdap::Connection#establish_connection` were all deprecated in favor of `setup_connection`.

Part of #205.