### PR TITLE
Remove deprecated `:ldap_scope` configuration option

### DIFF
--- a/lib/active_ldap/configuration.rb
+++ b/lib/active_ldap/configuration.rb
@@ -133,6 +133,9 @@ module ActiveLdap
           when :base
             # Scrub before inserting
             target.base = value.gsub(/['}{#]/, '')
+          when :scope
+            target.scope = value
+            configuration[:scope] = value
           else
             configuration[key] = value
           end

--- a/lib/active_ldap/configuration.rb
+++ b/lib/active_ldap/configuration.rb
@@ -133,14 +133,6 @@ module ActiveLdap
           when :base
             # Scrub before inserting
             target.base = value.gsub(/['}{#]/, '')
-          when :scope, :ldap_scope
-            if key == :ldap_scope
-              message = _(":ldap_scope configuration option is deprecated. " \
-                          "Use :scope instead.")
-              ActiveLdap.deprecator.warn(message)
-            end
-            target.scope = value
-            configuration[:scope] = value
           else
             configuration[key] = value
           end

--- a/lib/active_ldap/connection.rb
+++ b/lib/active_ldap/connection.rb
@@ -94,12 +94,6 @@ module ActiveLdap
         unless Adapter::Base.respond_to?(adapter_method)
           raise AdapterNotFound.new(adapter)
         end
-        if config.has_key?(:ldap_scope)
-          message = _(":ldap_scope connection option is deprecated. " \
-                      "Use :scope instead.")
-          ActiveLdap.deprecator.warn(message)
-          config[:scope] ||= config.delete(:ldap_scope)
-        end
         config = remove_connection_related_configuration(config)
         Adapter::Base.send(adapter_method, config)
       end

--- a/lib/active_ldap/operations.rb
+++ b/lib/active_ldap/operations.rb
@@ -62,12 +62,6 @@ module ActiveLdap
         filter = [:and, filter, *object_class_filters(classes)]
         _base = options[:base] ? [options[:base]] : [prefix, base]
         _base = prepare_search_base(_base)
-        if options.has_key?(:ldap_scope)
-          message = _(":ldap_scope search option is deprecated. " \
-                      "Use :scope instead.")
-          ActiveLdap.deprecator.warn(message)
-          options[:scope] ||= options[:ldap_scope]
-        end
         search_options = {
           :base => _base,
           :scope => options[:scope] || scope,

--- a/po/en/active-ldap.po
+++ b/po/en/active-ldap.po
@@ -3537,10 +3537,6 @@ msgstr ""
 msgid "parent must be an entry or parent DN: %s"
 msgstr ""
 
-#: lib/active_ldap/operations.rb:49
-msgid ":ldap_scope search option is deprecated. Use :scope instead."
-msgstr ""
-
 #: lib/active_ldap/operations.rb:258
 msgid "Invalid order: %s"
 msgstr ""
@@ -3835,10 +3831,6 @@ msgstr ""
 msgid "Attribute %s: Hash must have one key-value pair only: %s"
 msgstr ""
 
-#: lib/active_ldap/connection.rb:98
-msgid ":ldap_scope connection option is deprecated. Use :scope instead."
-msgstr ""
-
 #: lib/active_ldap/connection.rb:236
 msgid "since 1.1.0. "
 msgstr ""
@@ -3939,10 +3931,6 @@ msgstr ""
 
 #: lib/active_ldap/configuration.rb:70
 msgid "%s connection is not configured"
-msgstr ""
-
-#: lib/active_ldap/configuration.rb:110
-msgid ":ldap_scope configuration option is deprecated. Use :scope instead."
 msgstr ""
 
 #: lib/active_ldap/configuration.rb:131

--- a/po/ja/active-ldap.po
+++ b/po/ja/active-ldap.po
@@ -3549,11 +3549,6 @@ msgstr "LDAPサーバへの再接続を諦めました。"
 msgid "parent must be an entry or parent DN: %s"
 msgstr "親はエントリかDNでなければいけません: %s"
 
-#: lib/active_ldap/operations.rb:49
-msgid ":ldap_scope search option is deprecated. Use :scope instead."
-msgstr ""
-":ldap_search検索オプションは廃止予定です。代わりに:scopeを使ってください。"
-
 #: lib/active_ldap/operations.rb:258
 msgid "Invalid order: %s"
 msgstr "不正な順序です: %s"
@@ -3854,11 +3849,6 @@ msgstr "属性%sは単一の値しか持てません: %s"
 msgid "Attribute %s: Hash must have one key-value pair only: %s"
 msgstr "属性 %s: ハッシュはひとつのキー・値のペアしか持ってはいけません: %s"
 
-#: lib/active_ldap/connection.rb:98
-msgid ":ldap_scope connection option is deprecated. Use :scope instead."
-msgstr ""
-":ldap_scope接続オプションは廃止予定です。代わりに:scopeを使ってください。"
-
 #: lib/active_ldap/connection.rb:236
 msgid "since 1.1.0. "
 msgstr "1.1.0から。"
@@ -3960,11 +3950,6 @@ msgstr "'%{file}'を無視します。まず依存関係を解決してくださ
 #: lib/active_ldap/configuration.rb:70
 msgid "%s connection is not configured"
 msgstr "%sの接続は設定されていません"
-
-#: lib/active_ldap/configuration.rb:110
-msgid ":ldap_scope configuration option is deprecated. Use :scope instead."
-msgstr ""
-":ldap_scope設定オプションは廃止予定です。代わりに:scopeを使ってください。"
 
 #: lib/active_ldap/configuration.rb:131
 msgid "invalid URI: %s"


### PR DESCRIPTION
The `:ldap_scope` configuration option has been replaced by the `:scope` option. This PR removes support for `:ldap_scope`.

Part of #205.