### PR TITLE
Remove deprecated possibility of defining callbacks on instances

### DIFF
--- a/lib/active_ldap/callbacks.rb
+++ b/lib/active_ldap/callbacks.rb
@@ -22,16 +22,6 @@ module ActiveLdap
       define_model_callbacks :save, :create, :update, :destroy
     end
 
-    module ClassMethods
-      def method_added(meth)
-        super
-        if CALLBACKS.include?(meth.to_sym)
-          ActiveLdap.deprecator.warn("Base##{meth} has been deprecated, please use Base.#{meth} :method instead", caller[0,1])
-          send(meth.to_sym, meth.to_sym)
-        end
-      end
-    end
-
     module CallbackedInstantiatable
       def instantiate(record)
         object = super(record)


### PR DESCRIPTION
This PR removes the deprecated functionality to define callbacks on class instances.

Part of #205.