### PR TITLE
Fixed frozen literal string warning

### DIFF
--- a/lib/active_ldap/distinguished_name.rb
+++ b/lib/active_ldap/distinguished_name.rb
@@ -80,7 +80,7 @@ module ActiveLdap
       end
 
       def scan_quoted_attribute_value(scanner)
-        result = String.new
+        result = +""
         until scanner.scan(/\"/)
           scanner.scan(/([^\\\"]*)/)
           quoted_strings = scanner[1]
@@ -97,7 +97,7 @@ module ActiveLdap
       end
 
       def scan_not_quoted_attribute_value(scanner)
-        result = String.new
+        result = +""
         until scanner.eos?
           prev_size = result.size
           pairs = collect_pairs(scanner)
@@ -116,7 +116,7 @@ module ActiveLdap
       end
 
       def collect_pairs(scanner)
-        result = String.new
+        result = +""
         while scanner.scan(PAIR_RE)
           if scanner[2]
             result << [scanner[2].hex].pack("C*")


### PR DESCRIPTION
This small change will fix deprecation warnings since frozen_string_literal is now default in Ruby 3.4