### PR TITLE
Suppress frozen string literal warnings

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -162,7 +162,7 @@ module ActiveLdap
     private
     def detect_nearest(line, column)
       lines = @ldif.lines
-      nearest = lines[line - 1] || ""
+      nearest = lines[line - 1] || +""
       if column - 1 == nearest.size # for JRuby 1.0.2 :<
         nearest << NEAREST_MARK
       else

--- a/lib/active_ldap/ldif.rb
+++ b/lib/active_ldap/ldif.rb
@@ -9,7 +9,7 @@ module ActiveLdap
       def encode(attributes)
         return "" if attributes.empty?
 
-        result = ""
+        result = +""
         normalize(attributes).sort_by {|name,| name}.each do |name, values|
           values.each do |options, value|
             result << Attribute.encode([name, *options].join(";"), value)

--- a/lib/active_ldap/user_password.rb
+++ b/lib/active_ldap/user_password.rb
@@ -100,7 +100,7 @@ module ActiveLdap
 
       module_function
       def generate(length)
-        salt = ""
+        salt = +""
         length.times {salt << CHARS[rand(CHARS.length)]}
         salt
       end

--- a/test/test_connection.rb
+++ b/test/test_connection.rb
@@ -51,7 +51,7 @@ class TestConnection < Test::Unit::TestCase
         raise
       end
     end
-    expected_message = "Unknown key: :bind_format. Valid keys are: "
+    expected_message = +"Unknown key: :bind_format. Valid keys are: "
     valid_keys = ActiveLdap::Adapter::Base::VALID_ADAPTER_CONFIGURATION_KEYS
     expected_message << valid_keys.collect(&:inspect).join(", ")
     assert_equal(expected_message, exception.message)

--- a/test/test_ldif.rb
+++ b/test/test_ldif.rb
@@ -1207,7 +1207,7 @@ EOL
   end
 
   def test_records_with_external_file_reference_to_s
-    ldif_source = <<-EOL
+    ldif_source = (+<<-EOL).force_encoding("UTF-8")
 version: 1
 dn: cn=Horatio Jensen, ou=Product Testing, dc=airius, dc=com
 objectclass: top
@@ -1220,7 +1220,6 @@ uid: hjensen
 telephonenumber: +1 408 555 1212
 jpegphoto:< file://#{jpeg_photo_path}
 EOL
-    set_encoding(ldif_source, "utf-8")
 
     jpeg_photo_attribute = +"jpegphoto:: "
     value = [jpeg_photo].pack("m").gsub(/\n/, '')
@@ -1248,7 +1247,7 @@ EOL
   end
 
   def test_record_with_external_file_reference_is_invalid
-    ldif_source = <<-EOL
+    ldif_source = (+<<-EOL).force_encoding("UTF-8")
 version: 1
 dn: cn=Horatio Jensen, ou=Product Testing, dc=airius, dc=com
 objectclass: top
@@ -1269,7 +1268,7 @@ EOL
   end
 
   def test_records_with_option_attributes
-    ldif_source = <<-EOL
+    ldif_source = (+<<-EOL).force_encoding("UTF-8")
 version: 1
 dn:: b3U95Za25qWt6YOoLG89QWlyaXVz
 # dn:: ou=<JapaneseOU>,o=Airius
@@ -1325,7 +1324,6 @@ sn;lang-en: Ogasawara
 cn;lang-en: Rodney Ogasawara
 title;lang-en: Sales, Director
 EOL
-    set_encoding(ldif_source, "utf-8")
 
     record1 = {
       "dn" => "ou=営業部,o=Airius",
@@ -1397,7 +1395,7 @@ EOL
   end
 
   def test_records_with_option_attributes_to_s
-    ldif_source = <<-EOL
+    ldif_source = (+<<-EOL).force_encoding("UTF-8")
 version: 1
 dn:: b3U95Za25qWt6YOoLG89QWlyaXVz
 # dn:: ou=<JapaneseOU>,o=Airius
@@ -1453,7 +1451,6 @@ sn;lang-en: Ogasawara
 cn;lang-en: Rodney Ogasawara
 title;lang-en: Sales, Director
 EOL
-    set_encoding(ldif_source, "utf-8")
 
     assert_ldif_to_s(<<-EOL, ldif_source)
 version: 1
@@ -1865,14 +1862,13 @@ EOL
 
   private
   def assert_ldif(version, records, ldif_source)
-    encoding = ldif_source.encoding if ldif_source.respond_to?(:encoding)
     ldif = ActiveLdap::Ldif.parse(ldif_source)
     assert_equal(version, ldif.version)
     assert_equal(records,
                  ldif.records.collect {|record| record.to_hash})
 
     regenerated_ldif = ldif.to_s
-    set_encoding(regenerated_ldif, encoding)
+    regenerated_ldif.force_encoding(ldif_source.encoding)
     reparsed_ldif = ActiveLdap::Ldif.parse(regenerated_ldif)
     assert_equal(ldif, reparsed_ldif)
 
@@ -1903,9 +1899,5 @@ EOL
   def assert_ldif_to_s(expected_ldif_source, original_ldif_source)
     ldif = ActiveLdap::Ldif.parse(original_ldif_source)
     assert_equal(expected_ldif_source, ldif.to_s)
-  end
-
-  def set_encoding(string, encoding)
-    string = string.dup.force_encoding("utf-8") if string.respond_to?(:force_encoding)
   end
 end

--- a/test/test_ldif.rb
+++ b/test/test_ldif.rb
@@ -1222,7 +1222,7 @@ jpegphoto:< file://#{jpeg_photo_path}
 EOL
     set_encoding(ldif_source, "utf-8")
 
-    jpeg_photo_attribute = "jpegphoto:: "
+    jpeg_photo_attribute = +"jpegphoto:: "
     value = [jpeg_photo].pack("m").gsub(/\n/, '')
     first_line_value_size = 75 - jpeg_photo_attribute.size
     jpeg_photo_attribute << value[0, first_line_value_size] + "\n"
@@ -1906,6 +1906,6 @@ EOL
   end
 
   def set_encoding(string, encoding)
-    string.force_encoding("utf-8") if string.respond_to?(:force_encoding)
+    string = string.dup.force_encoding("utf-8") if string.respond_to?(:force_encoding)
   end
 end

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -575,7 +575,7 @@ class TestSchema < Test::Unit::TestCase
         end
 
         def test_do_nothing
-          value = ""
+          value = +""
           value.force_encoding("UTF-8")
           @attribute.apply_encoding(value)
           assert_equal(Encoding::UTF_8, value.encoding)
@@ -601,27 +601,21 @@ class TestSchema < Test::Unit::TestCase
         end
 
         def test_string
-          value = ""
+          value = +""
           value.force_encoding("UTF-8")
           @attribute.apply_encoding(value)
           assert_equal(Encoding::ASCII_8BIT, value.encoding)
         end
 
         def test_array
-          values = [""]
-          values.each do |value|
-            value.force_encoding("UTF-8")
-          end
+          values = ["".dup.force_encoding("UTF-8")]
           @attribute.apply_encoding(values)
           assert_equal([Encoding::ASCII_8BIT],
                        values.collect(&:encoding))
         end
 
         def test_hash
-          values = {:binary => ""}
-          values.each_value do |value|
-            value.force_encoding("UTF-8")
-          end
+          values = {:binary => "".dup.force_encoding("UTF-8")}
           @attribute.apply_encoding(values)
           assert_equal([Encoding::ASCII_8BIT],
                        values.each_value.collect(&:encoding))

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -608,14 +608,14 @@ class TestSchema < Test::Unit::TestCase
         end
 
         def test_array
-          values = ["".dup.force_encoding("UTF-8")]
+          values = [(+"").force_encoding("UTF-8")]
           @attribute.apply_encoding(values)
           assert_equal([Encoding::ASCII_8BIT],
                        values.collect(&:encoding))
         end
 
         def test_hash
-          values = {:binary => "".dup.force_encoding("UTF-8")}
+          values = {:binary => (+"").force_encoding("UTF-8")}
           @attribute.apply_encoding(values)
           assert_equal([Encoding::ASCII_8BIT],
                        values.each_value.collect(&:encoding))

--- a/test/test_validation.rb
+++ b/test/test_validation.rb
@@ -48,7 +48,7 @@ class TestValidation < Test::Unit::TestCase
 
   def test_octet_string
     make_temporary_user(:simple => true) do |user,|
-      utf8_encoded_binary_value = "\xff".force_encoding("UTF-8")
+      utf8_encoded_binary_value = "\xff".dup.force_encoding("UTF-8")
       user.user_password = utf8_encoded_binary_value
       assert_true(user.save)
       assert_equal([], user.errors.full_messages)

--- a/test/test_validation.rb
+++ b/test/test_validation.rb
@@ -48,7 +48,7 @@ class TestValidation < Test::Unit::TestCase
 
   def test_octet_string
     make_temporary_user(:simple => true) do |user,|
-      utf8_encoded_binary_value = "\xff".dup.force_encoding("UTF-8")
+      utf8_encoded_binary_value = (+"\xff").force_encoding("UTF-8")
       user.user_password = utf8_encoded_binary_value
       assert_true(user.save)
       assert_equal([], user.errors.full_messages)


### PR DESCRIPTION
https://github.com/activeldap/activeldap/pull/213 was merged, however there still exist "warning: literal string will be frozen in the future" warnings on ruby 3.4 and later environment.

This suppressed such warnings except the following:

https://github.com/activeldap/activeldap/actions/runs/24625310333/job/72003165397?pr=220#step:3:1409

```text
  test_invalid_subtype_and_single_value:		.: (0.176535)
/source/lib/active_ldap/schema.rb:443: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

Let's work on it separately.
